### PR TITLE
#13 Italic comments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ or on specific events.
 Plug 'arcticicestudio/nord-vim', { 'on':  'NERDTreeToggle' }
 ```
 
+### Configuration
+All options should be set **before** the [activation](#activation) command!
+
+#### Italic comments
+**This option should only be enabled if your terminal emulator supports italics!**
+
+Enable to use italic font for all comments.
+
+To adhere to the Nord style guide this option is disabled by default.
+It can be enabled by setting the `g:nord_italic_comments` variable to `1`.  
+```vim
+let g:nord_italic_comments = 1
+```
+
 ## Plugin Support
 Nord Vim provides support for many third-party language- and the UI plugins.  
 

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -48,7 +48,16 @@ let s:nord13_term = "3"
 let s:nord14_term = "2"
 let s:nord15_term = "5"
 
+if !exists('g:nord_italic_comments')
+  let g:nord_italic_comments = 0
+endif
+
 function! s:hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+  let l:attr = a:attr
+  if g:nord_italic_comments == 0 && l:attr ==? 'italic'
+    let l:attr= 'NONE'
+  endif
+
   if a:guifg != ""
     exec "hi " . a:group . " guifg=" . a:guifg
   endif
@@ -62,7 +71,7 @@ function! s:hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
     exec "hi " . a:group . " ctermbg=" . a:ctermbg
   endif
   if a:attr != ""
-    exec "hi " . a:group . " gui=" . a:attr . " cterm=" . a:attr
+    exec "hi " . a:group . " gui=" . l:attr . " cterm=" . l:attr
   endif
   if a:guisp != ""
     exec "hi " . a:group . " guisp=" . a:guisp
@@ -137,7 +146,7 @@ call s:hi("VertSplit", s:nord2_gui, s:nord1_gui, s:nord3_term, s:nord1_term, "NO
 "+----------------------+
 call s:hi("Boolean", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("Character", s:nord14_gui, "", s:nord14_term, "", "", "")
-call s:hi("Comment", s:nord3_gui, "", s:nord3_term, "", "", "")
+call s:hi("Comment", s:nord3_gui, "", s:nord3_term, "", "italic", "")
 call s:hi("Conditional", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("Constant", s:nord4_gui, "", "NONE", "", "", "")
 call s:hi("Define", s:nord9_gui, "", s:nord9_term, "", "", "")
@@ -155,7 +164,7 @@ call s:hi("PreProc", s:nord9_gui, "", s:nord9_term, "", "NONE", "")
 call s:hi("Repeat", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("Special", s:nord4_gui, "", "NONE", "", "", "")
 call s:hi("SpecialChar", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("SpecialComment", s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("SpecialComment", s:nord8_gui, "", s:nord8_term, "", "italic", "")
 call s:hi("Statement", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("StorageClass", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("String", s:nord14_gui, "", s:nord14_term, "", "", "")


### PR DESCRIPTION
**Related issue**: #13
This PR implements the global configuration variable `g:nord_italic_comments` to support italic comments.

/cc @kepbod 