### PR TITLE
Add basic support for CtrlP

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -388,6 +388,11 @@ call s:hi("NERDTreeExecFile", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link NERDTreeDirSlash Keyword
 hi! link NERDTreeHelp Comment
 
+" CtrlP
+" > ctrlpvim/ctrlp.vim
+hi! link CtrlPMatch Keyword
+hi! link CtrlPBufferHid Normal
+
 "+--- Languages ---+
 " JavaScript
 " > pangloss/vim-javascript


### PR DESCRIPTION
This patch adds the following features :

* [1] Matched characters are using Keyword color (instead of normal color in that case we do not see the matched characters)
* [2] Already opened buffers now take the normal color (instead of comment color)

[1]
![screenshot-20170529060054-550x64](https://cloud.githubusercontent.com/assets/9877335/26545769/c58403a6-441b-11e7-9084-a6079d42484f.png)

[2]
![screenshot-20170529055952-551x86](https://cloud.githubusercontent.com/assets/9877335/26545768/c5828968-441b-11e7-9f0c-50161ececa14.png)
