### PR TITLE
Add plugin support for vim-plug

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -118,6 +118,7 @@ call s:hi("Underline", "", "", "", "", "underline", "")
 call s:hi("ColorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 call s:hi("Cursor", s:nord0_gui, s:nord4_gui, "", "NONE", "", "")
 call s:hi("CursorLine", "", s:nord1_gui, "NONE", s:nord1_term, "NONE", "")
+call s:hi("Error", s:nord0_gui, s:nord11_gui, "", s:nord11_term, "", "")
 call s:hi("iCursor", s:nord0_gui, s:nord4_gui, "", "NONE", "", "")
 call s:hi("LineNr", s:nord3_gui, s:nord0_gui, s:nord3_term, "NONE", "", "")
 call s:hi("MatchParen", s:nord0_gui, s:nord8_gui, s:nord1_term, s:nord8_term, "", "")
@@ -435,6 +436,10 @@ hi! link NERDTreeHelp Comment
 " > ctrlpvim/ctrlp.vim
 hi! link CtrlPMatch Keyword
 hi! link CtrlPBufferHid Normal
+
+" vim-plug
+" > junegunn/vim-plug
+call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
 
 "+--- Languages ---+
 " JavaScript


### PR DESCRIPTION
> Closes #43

This adds support for [junegunn/vim-plug](https://github.com/junegunn/vim-plug/) for the `PlugClean` command which used the `Ignore` group for deleted directory listings resulting in unreadable text when `cursorline` has been set.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/30959403-53d9cd0a-a440-11e7-8c38-3045e280131a.gif"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/30959419-618876ea-a440-11e7-8895-6e9acfd8b830.gif"/></p>
