### PR TITLE
Link legacy diff groups for git.vim and diff.vim syntax

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -306,6 +306,10 @@ else
   call s:hi("DiffDelete", s:nord11_gui, s:nord1_gui, s:nord11_term, s:nord1_term, "", "")
   call s:hi("DiffText", s:nord13_gui, s:nord1_gui, s:nord13_term, s:nord1_term, "", "")
 endif
+" Legacy groups for official git.vim and diff.vim syntax
+hi! link diffAdded DiffAdd
+hi! link diffChanged DiffChange
+hi! link diffRemoved DiffDelete
 
 call s:hi("gitconfigVariable", s:nord7_gui, "", s:nord7_term, "", "", "")
 


### PR DESCRIPTION
> Closes #66

The official `git.vim` and `diff.vim` syntax uses different groups for `diff`:

* [`diffAdded` and `diffRemoved`][add-rem]
* [`diffChanged`][changed]

These groups are not in the [official vim documentation][docs], but are still used by the syntax for example when run with `git commit --verbose`

This PR links these legacy groups to their respective groups.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/32219558-d906cf5c-be2e-11e7-98e7-d22583bac4f0.png"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/32219588-f00e0c4c-be2e-11e7-91e7-87bb28c48721.png"/></p>

[add-rem]: https://github.com/vim/vim/search?q=diffAdded+diffRemoved
[changed]: https://github.com/vim/vim/search?q=diffChanged
[docs]: http://vimdoc.sourceforge.net/htmldoc/syntax.html#hl-DiffAdd