### PR TITLE
fixes invisible inactive lightline bar

### DIFF
--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -32,7 +32,7 @@ let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
 let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
 
 let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
-let s:p.inactive.middle = [ [ s:nord5, s:nord0 ] ]
+let s:p.inactive.middle = [ [ s:nord5, s:nord1 ] ]
 let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 
 let s:p.insert.left = [ [ s:nord1, s:nord6 ], [ s:nord5, s:nord1 ] ]


### PR DESCRIPTION
I decided to try lightline, and I couldn't figure out where the statusbar was when in bottom split.

OLD:

![screenshot from 2017-11-18 21-51-52](https://user-images.githubusercontent.com/7635158/32986925-d6a79234-ccaa-11e7-9561-43daffa1722c.png)

NEW:

![screenshot from 2017-11-18 21-52-45](https://user-images.githubusercontent.com/7635158/32986927-e41880f4-ccaa-11e7-9444-316958ec74c1.png)

Also
--

Be sure that this makes its way into the `lightline` repository .. because the only way I could fix it was by modifying `~/.vim/plugged/lightline.vim/autoload/lightline/colorscheme/nord.vim` (rather than your `~/.vim/plugged/nord-vim/autoload/lightline/colorscheme/nord.vim`).