### PR TITLE
Fugitive syntax highlting

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -387,6 +387,12 @@ call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 
+" fugitive.vim
+" > tpope/vim-fugitive
+call s:hi("gitcommitDiscardedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("gitcommitUntrackedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("gitcommitSelectedFile", s:nord14_gui, "", s:nord14_term, "", "", "")
+
 " davidhalter/jedi-vim
 call s:hi("jediFunction", s:nord4_gui, s:nord3_gui, "", s:nord3_term, "", "")
 call s:hi("jediFat", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "bold,underline", "")


### PR DESCRIPTION
Adds syntax highlighting for filenames using [fugitive](https://github.com/tpope/vim-fugitive)'s `:Gstatus` window.

![2017-11-29 18 05 25](https://user-images.githubusercontent.com/6628875/33404056-def50276-d530-11e7-8e76-5733f58f7139.gif)

Fixes #76.
