### PR TITLE
Fix "WildMenu" background color for current selection (tab completion)

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -191,7 +191,7 @@ else
   call s:hi("StatusLineNC", s:nord4_gui, s:nord3_gui, "NONE", s:nord3_term, "NONE", "")
 endif
 call s:hi("WarningMsg", s:nord0_gui, s:nord13_gui, s:nord1_term, s:nord13_term, "", "")
-call s:hi("WildMenu", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "", "")
+call s:hi("WildMenu", s:nord8_gui, s:nord1_gui, s:nord8_term, s:nord1_term, "", "")
 
 "+--- Search ---+
 call s:hi("IncSearch", s:nord1_gui, s:nord8_gui, s:nord1_term, s:nord8_term, "underline", "")


### PR DESCRIPTION
> Fixes #64
> Related to #58

The implemented feature in #58 changed the background color of the status bar (`StatusLine`) group to `nord3`, but the `WildMenu` group also used `nord3` as background color for the current tab selection.

This PR changes the `WildMenu` background color to `nord1` which is available for both terminal (`nord1_term`) and GUI (`nord1_gui`) mode.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/33609457-76d72fce-d9c8-11e7-9048-d2c6c7ed7800.gif"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/33609464-806ee55e-d9c8-11e7-8020-58030141fac3.gif"/></p>
