### PR TITLE
Colorize vim-signify signs

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -460,6 +460,13 @@ call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 
+" Signify
+" > mhinz/vim-signify
+call s:hi("SignifySignAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
+call s:hi("SignifySignChange", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("SignifySignChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("SignifySignDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+
 " fugitive.vim
 " > tpope/vim-fugitive
 call s:hi("gitcommitDiscardedFile", s:nord11_gui, "", s:nord11_term, "", "", "")


### PR DESCRIPTION
All signs of [vim-signify](https://github.com/mhinz/vim-signify) get the same colors as GitGutter uses.