### PR TITLE
Highlighting for links in help

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -326,6 +326,9 @@ call s:hi("gitconfigVariable", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("goBuiltins", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link goConstants Keyword
 
+call s:hi("helpBar", s:nord3_gui, "", s:nord3_term, "", "", "")
+call s:hi("helpHyperTextJump", s:nord8_gui, "", s:nord8_term, "", "underline", "")
+
 call s:hi("htmlArg", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("htmlLink", s:nord4_gui, "", "", "", "NONE", "NONE")
 hi! link htmlBold Bold


### PR DESCRIPTION
> Closes #85

The color of links in help was the same as normal text making it impossible to to distinguish between both.
Includes the help bars when enabled with `:set conceallevel=2`.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/34460697-25f5be7e-ee16-11e7-9c57-32bb2ec15314.png"/></p>

<p align="center"><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/34460700-35bddeea-ee16-11e7-976b-e00cfe80c462.png"/></p>
