### PR TITLE
Make the neovim terminal cursor visible when out of terminal mode

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -157,10 +157,10 @@ call s:hi("VisualNOS", "", s:nord2_gui, "", s:nord1_term, "", "")
 call s:hi("healthError", s:nord11_gui, s:nord1_gui, s:nord11_term, s:nord1_term, "", "")
 call s:hi("healthSuccess", s:nord14_gui, s:nord1_gui, s:nord14_term, s:nord1_term, "", "")
 call s:hi("healthWarning", s:nord13_gui, s:nord1_gui, s:nord13_term, s:nord1_term, "", "")
+call s:hi("TermCursorNC", "", s:nord1_gui, "", s:nord1_term, "", "")
 
 "+- Neovim Terminal Colors -+
 if has('nvim')
-  call s:hi("TermCursorNC", "", s:nord1_gui, "", s:nord1_term, "", "")
   let g:terminal_color_0 = s:nord1_gui
   let g:terminal_color_1 = s:nord11_gui
   let g:terminal_color_2 = s:nord14_gui

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -160,6 +160,7 @@ call s:hi("healthWarning", s:nord13_gui, s:nord1_gui, s:nord13_term, s:nord1_ter
 
 "+- Neovim Terminal Colors -+
 if has('nvim')
+  call s:hi("TermCursorNC", "", s:nord1_gui, "", s:nord1_term, "", "")
   let g:terminal_color_0 = s:nord1_gui
   let g:terminal_color_1 = s:nord11_gui
   let g:terminal_color_2 = s:nord14_gui


### PR DESCRIPTION
In the neovim terminal when you exit the terminal mode and navigate around the terminal window, or to another window you loose track of the current cursor position if TermCursorNC is not set.