### PR TITLE
Fixes StatusLineTerm colors

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -198,9 +198,13 @@ call s:hi("Question", s:nord4_gui, "", "NONE", "", "", "")
 if g:nord_uniform_status_lines == 0
   call s:hi("StatusLine", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "NONE", "")
   call s:hi("StatusLineNC", s:nord4_gui, s:nord1_gui, "NONE", s:nord1_term, "NONE", "")
+  call s:hi("StatusLineTerm", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "NONE", "")
+  call s:hi("StatusLineTermNC", s:nord4_gui, s:nord1_gui, "NONE", s:nord1_term, "NONE", "")
 else
   call s:hi("StatusLine", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "NONE", "")
   call s:hi("StatusLineNC", s:nord4_gui, s:nord3_gui, "NONE", s:nord3_term, "NONE", "")
+  call s:hi("StatusLineTerm", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, "NONE", "")
+  call s:hi("StatusLineTermNC", s:nord4_gui, s:nord3_gui, "NONE", s:nord3_term, "NONE", "")
 endif
 call s:hi("WarningMsg", s:nord0_gui, s:nord13_gui, s:nord1_term, s:nord13_term, "", "")
 call s:hi("WildMenu", s:nord8_gui, s:nord1_gui, s:nord8_term, s:nord1_term, "", "")


### PR DESCRIPTION
> Supersedes #103 

before:
![screenshot from 2018-03-09 22-08-32](https://user-images.githubusercontent.com/7635158/37237786-9b89ff8c-23e6-11e8-8c53-f7dae518b332.png)

after:
![screenshot from 2018-03-09 22-09-32](https://user-images.githubusercontent.com/7635158/37237787-9b9dcee0-23e6-11e8-848c-b64b059afa14.png)

This makes `StatusLineTerm` and `StatusLineTermNC` for both vim and neovim be more consistent with the regular statusline colors.