### PR TITLE
Add line number brightness feature

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -99,6 +99,10 @@ if !exists("g:nord_comment_brightness")
   let g:nord_comment_brightness = 0
 endif
 
+if !exists("g:nord_line_number_brightness")
+  let g:nord_line_number_brightness = 0
+end
+
 if !exists("g:nord_uniform_diff_background")
   let g:nord_uniform_diff_background = 0
 endif
@@ -185,6 +189,10 @@ call s:hi("CursorLineNr", s:nord3_gui, s:nord0_gui, "NONE", "", "", "")
 call s:hi("Folded", s:nord3_gui, s:nord1_gui, s:nord3_term, s:nord1_term, "bold", "")
 call s:hi("FoldColumn", s:nord3_gui, s:nord0_gui, s:nord3_term, "NONE", "", "")
 call s:hi("SignColumn", s:nord1_gui, s:nord0_gui, s:nord1_term, "NONE", "", "")
+if g:nord_line_number_brightness == 1
+  call s:hi("LineNr", s:nord4_gui, s:nord0_gui, s:nord3_term, "NONE", "", "")
+  call s:hi("CursorLineNr", s:nord4_gui, s:nord0_gui, "NONE", "", "", "")
+endif
 
 "+--- Navigation ---+
 call s:hi("Directory", s:nord8_gui, "", s:nord8_term, "NONE", "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -101,7 +101,7 @@ endif
 
 if !exists("g:nord_line_number_brightness")
   let g:nord_line_number_brightness = 0
-end
+endif
 
 if !exists("g:nord_uniform_diff_background")
   let g:nord_uniform_diff_background = 0


### PR DESCRIPTION
Add an option to set line number's foreground color to `nord4_gui` for a better view.

`let g:nord_line_number_brightness = 0`:

<img width="781" alt="screen shot 2018-03-17 at 5 28 31 pm" src="https://user-images.githubusercontent.com/17645203/37554291-d6b4b840-2a08-11e8-9b82-1d5c5d36121d.png">

`let g:nord_line_number_brightness = 1`:

<img width="828" alt="screen shot 2018-03-17 at 5 29 14 pm" src="https://user-images.githubusercontent.com/17645203/37554305-0818cc78-2a09-11e8-856e-7891d97dd4f7.png">