### PR TITLE
Link jsThis highlight to keyword.

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -522,6 +522,7 @@ call s:hi("jsGlobalNodeObjects", s:nord8_gui, "", s:nord8_term, "", s:italic, ""
 hi! link jsBrackets Delimiter
 hi! link jsFuncCall Function
 hi! link jsFuncParens Delimiter
+hi! link jsThis Keyword
 hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword
 hi! link jsRegexpString SpecialChar


### PR DESCRIPTION
Hi,

I noticed that highlight for `this` in javascript is missing. I linked it to `Keyword`, but if you think something else would suit better, let me know.

Before:
![screenshot](https://i.imgur.com/ZMJlgTB.png)

After:
![screenshot_after](https://i.imgur.com/6zyBjnV.png)