### PR TITLE
Highlight Yaml keys

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -549,3 +549,7 @@ hi! link mkdLinkDef mkdLink
 hi! link mkdLinkDefTarget mkdURL
 hi! link mkdLinkTitle mkdInlineURL
 hi! link mkdDelimiter Keyword
+
+" YAML
+" > stephpy/vim-yaml
+call s:hi("yamlKey", s:nord7_gui, "", s:nord7_term, "", "", "")


### PR DESCRIPTION
I'm using nord-vim together w/ vim-polyglot which uses [`vim-yaml`](https://github.com/stephpy/vim-yaml/) that identifies `yamlKey` as an `Identifier` which gets picked up by Nord as the whitish `nord4_gui`

Adding this creates for a much nicer bluish highlighting on the yaml keys similar to json keys

![screenshot 2018-05-02 07 43 00](https://user-images.githubusercontent.com/3429763/39521440-81d469ae-4ddc-11e8-9ab0-3ab703d009e9.png)
