### PR TITLE
Add support for vim-signature higlighting

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -515,6 +515,10 @@ hi! link CtrlPBufferHid Normal
 " > junegunn/vim-plug
 call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
 
+" vim-signature
+" > kshenoy/vim-signature
+call s:hi("SignatureMarkText", s:nord8_gui, "", s:nord8_term, "", "", "")
+
 "+--- Languages ---+
 " JavaScript
 " > pangloss/vim-javascript


### PR DESCRIPTION
It's a [plugin](https://github.com/kshenoy/vim-signature) to display marks on the marge.

<img width="624" alt="screen shot 2018-05-06 at 8 02 41 am" src="https://user-images.githubusercontent.com/2859122/39670409-975b59c4-5104-11e8-90a3-646ca433e978.png">
