### PR TITLE
Improve compatibility of airline with tmuxline.vim plugin

### DIFF
--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -44,25 +44,25 @@ let s:nord6_term = "15"
 
 let s:NMain = [s:nord1_gui, s:nord8_gui, s:nord1_term, s:nord8_term]
 let s:NRight = [s:nord1_gui, s:nord9_gui, s:nord1_term, s:nord9_term]
-let s:NMiddle = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
+let s:NMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let g:airline#themes#nord#palette.normal = airline#themes#generate_color_map(s:NMain, s:NRight, s:NMiddle)
 
 let s:IMain = [s:nord1_gui, s:nord14_gui, s:nord1_term, s:nord6_term]
 let s:IRight = [s:nord1_gui, s:nord9_gui, s:nord1_term, s:nord9_term]
-let s:IMiddle = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
+let s:IMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let g:airline#themes#nord#palette.insert = airline#themes#generate_color_map(s:IMain, s:IRight, s:IMiddle)
 
 let s:RMain = [s:nord1_gui, s:nord14_gui, s:nord1_term, s:nord14_term]
 let s:RRight = [s:nord1_gui, s:nord9_gui, s:nord1_term, s:nord9_term]
-let s:RMiddle = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
+let s:RMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let g:airline#themes#nord#palette.replace = airline#themes#generate_color_map(s:RMain, s:RRight, s:RMiddle)
 
 let s:VMain = [s:nord1_gui, s:nord7_gui, s:nord1_term, s:nord7_term]
 let s:VRight = [s:nord1_gui, s:nord9_gui, s:nord1_term, s:nord9_term]
-let s:VMiddle = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
+let s:VMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let g:airline#themes#nord#palette.visual = airline#themes#generate_color_map(s:VMain, s:VRight, s:VMiddle)
 
-let s:IAMain = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
-let s:IARight = [s:nord4_gui, s:nord3_gui, s:nord4_term, s:nord3_term]
-let s:IAMiddle = [s:nord4_gui, s:nord1_gui, s:nord4_term, s:nord1_term]
+let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+let s:IAMiddle = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
 let g:airline#themes#nord#palette.inactive = airline#themes#generate_color_map(s:IAMain, s:IARight, s:IAMiddle)


### PR DESCRIPTION
> Closes #117

The [Nord airline.vim][nal] UI plugin theme now includes better support for the [tmuxline.vim][] plugin. Previously text shown in the main segment of the _tmuxline_, generated via the `:Tmuxline airline` command, caused a `bad colour: NONE` error or has been colorized using `nord0` which resulted in unreadable text due to a `nord3` background.

This has been fixed by using `nord5` as foreground color. #11 which has been used as implementation reference that fixed the same incompatibility for the [lightline.vim][] plugin.

![gh-117-preview](https://user-images.githubusercontent.com/7836623/41835439-e3f2388c-7857-11e8-91e0-a0440b7ecf35.png)

[nal]: https://github.com/arcticicestudio/nord-vim/blob/develop/autoload/airline/themes/nord.vim
[tmuxline.vim]: https://github.com/edkolev/tmuxline.vim
[lightline.vim]: https://github.com/itchyny/lightline.vim