### PR TITLE
Fix for terminal statusline in airline

### DIFF
--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -66,3 +66,9 @@ let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 let s:IAMiddle = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
 let g:airline#themes#nord#palette.inactive = airline#themes#generate_color_map(s:IAMain, s:IARight, s:IAMiddle)
+
+let g:airline#themes#nord#palette.normal.airline_term = s:NMiddle
+let g:airline#themes#nord#palette.insert.airline_term = s:IMiddle
+let g:airline#themes#nord#palette.replace.airline_term = s:RMiddle
+let g:airline#themes#nord#palette.visual.airline_term = s:VMiddle
+let g:airline#themes#nord#palette.inactive.airline_term = s:IAMiddle


### PR DESCRIPTION
Since ~~~neovim 0.3~~ recent updates to airline the airline and terminal buffers don't look as expected:
<img width="1576" alt="neovim term" src="https://user-images.githubusercontent.com/762115/43037653-d4345548-8d0f-11e8-9aea-1b77446418cb.png">
Setting these values seems to fix it.