### PR TITLE
Add more ALE Highlights

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -488,6 +488,8 @@ hi! link yamlDocumentStart Keyword
 " > w0rp/ale
 call s:hi("ALEWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("ALEWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+call s:hi("ALEError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
 
 " GitGutter
 " > airblade/vim-gitgutter


### PR DESCRIPTION
This adds colors and underlines for ALE Errors and Warnings. Also for language client Neovim than uses the same highlight groups as ALE