### PR TITLE
Haskell Syntax Plugin Support

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -548,6 +548,12 @@ call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
 call s:hi("SignatureMarkText", s:nord8_gui, "", s:nord8_term, "", "", "")
 
 "+--- Languages ---+
+" Haskell
+" > neovimhaskell/haskell-vim
+call s:hi("haskellPreProc", s:nord10_gui, "", s:nord10_term, "", "", "")
+call s:hi("haskellType", s:nord7_gui, "", s:nord7_term, "", "", "")
+hi! link haskellPragma haskellPreProc
+
 " JavaScript
 " > pangloss/vim-javascript
 call s:hi("jsGlobalNodeObjects", s:nord8_gui, "", s:nord8_term, "", s:italic, "")


### PR DESCRIPTION
> Resolves #104

Added support for Haskell syntax through the [neovimhaskell/haskell-vim][] plugin.
This includes better coloring for types/classes using `nord7` instead of highlighting them like keywords (`nord9`) and pre-processor and pragma elements are now colorized correctly with `nord10`.

#### Pragma

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56079623-6ee02780-5df7-11e9-8cfc-f3f62b1a79d4.png"/></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56079622-6e479100-5df7-11e9-9b80-650875c7fd55.png"/></p>

#### Pre-Processor

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56079625-6ee02780-5df7-11e9-9429-0ef098f31fb2.png"/></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56079624-6ee02780-5df7-11e9-8b85-33e624121d1e.png"/></p>

#### Types/Classes

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56079627-6ee02780-5df7-11e9-94c7-68952bfc1600.png"/></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56079626-6ee02780-5df7-11e9-904f-6fd27129c0f7.png"/></p>