### PR TITLE
Improve CMake generator expression highlighting

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -309,6 +309,8 @@ call s:hi("cIncluded", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link cOperator Operator
 hi! link cPreCondit PreCondit
 
+call s:hi("cmakeGeneratorExpression", s:nord10_gui, "", s:nord10_term, "", "", "")
+
 hi! link csPreCondit PreCondit
 hi! link csType Type
 hi! link csXmlTag SpecialComment


### PR DESCRIPTION
> Resolves #137 

[CMake generator expressions][ge] are now highlighted using `nord10` as foreground instead of `nord13` as background and `nord0` as foreground.

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56079970-99cc7a80-5dfb-11e9-9528-83bbe92c51d3.png"/></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56079969-99cc7a80-5dfb-11e9-8afa-68c7878521c4.png"/></p>

[ge]:  https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html