### PR TITLE
Basic syntax highlighting support for Rust

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -451,6 +451,18 @@ hi! link rubyLocalVariableOrMethod Function
 hi! link rubyPseudoVariable Keyword
 hi! link rubyRegexp SpecialChar
 
+call s:hi("rustAttribute", s:nord10_gui, "", s:nord10_term, "", "", "")
+call s:hi("rustEnum", s:nord7_gui, "", s:nord7_term, "", "bold", "")
+call s:hi("rustMacro", s:nord8_gui, "", s:nord8_term, "", "bold", "")
+call s:hi("rustModPath", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("rustPanic", s:nord9_gui, "", s:nord9_term, "", "bold", "")
+call s:hi("rustTrait", s:nord7_gui, "", s:nord7_term, "", s:italic, "")
+hi! link rustCommentLineDoc Comment
+hi! link rustDerive rustAttribute
+hi! link rustEnumVariant rustEnum
+hi! link rustEscape SpecialChar
+hi! link rustQuestionMark Keyword
+
 call s:hi("sassClass", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("sassId", s:nord7_gui, "", s:nord7_term, "", s:underline, "")
 hi! link sassAmpersand Keyword


### PR DESCRIPTION
> Resolves #138

Added basic syntax highlighting support for [Rust][].

[Traits][] and [enums][] are colorized with `nord7` and with bold font to make them visually stand out more.
Also [attributes][] and [derives][] are colored with `nord10`.

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56096828-3a4e9780-5eed-11e9-9d74-02b498a78ab1.png" /></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56096827-3a4e9780-5eed-11e9-8275-c97b2569f959.png" /></p>

[Macros][] are colorized with `nord8` and bold font to make them visually different from "normal" functions.

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56096834-463a5980-5eed-11e9-8d98-bbc814506779.png" /></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56096839-4df9fe00-5eed-11e9-8d8c-9a488105b0e9.png" /></p>

[Escape][] sequences are colored with `nord13`.

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56096843-58b49300-5eed-11e9-9bb2-5541b3d68689.png" /></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56096842-58b49300-5eed-11e9-9ab6-52b709119c81.png" /></p>

Import statements and paths are correctly colored with keyword and type colors.

<p align="center"><strong>Before</strong><img src="https://user-images.githubusercontent.com/7836623/56096847-623dfb00-5eed-11e9-91c3-cfe7621a2e5b.png" /></p>
<p align="center"><strong>After</strong><img src="https://user-images.githubusercontent.com/7836623/56096846-623dfb00-5eed-11e9-9cce-30f14bdc7e57.png" /></p>

[attributes]: https://doc.rust-lang.org/reference/attributes.html
[derives]: https://doc.rust-lang.org/edition-guide/rust-2018/macros/custom-derive.html
[enums]: https://doc.rust-lang.org/1.1.0/book/enums.html
[escapes]: https://doc.rust-lang.org/reference/tokens.html#ascii-escapes
[macros]: https://doc.rust-lang.org/1.8.0/book/macros.html
[rust]: https://www.rust-lang.org
[traits]: https://doc.rust-lang.org/book/ch10-02-traits.html
