### PR TITLE
adds coc error gutter support

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -508,6 +508,8 @@ call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 " > neoclide/coc
 call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -508,8 +508,6 @@ call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 " > neoclide/coc
 call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -504,6 +504,13 @@ hi! link yamlDocumentStart Keyword
 call s:hi("ALEWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 
+" Coc
+" > neoclide/coc
+call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+
 " GitGutter
 " > airblade/vim-gitgutter
 call s:hi("GitGutterAdd", s:nord14_gui, "", s:nord14_term, "", "", "")


### PR DESCRIPTION
Hi -- I recently started working with [coc](https://github.com/neoclide/coc.nvim) as my intellisense engine over `ale` and noticed that there wasn't any `nord-vim` support so I added it 😀.  

Thanks for all your work on this project and let me know what you think.