### PR TITLE
Update airline and lightline theme bundles to use uniform background color configuration

### DIFF
--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -78,9 +78,15 @@ let g:airline#themes#nord#palette.visual = airline#themes#generate_color_map(s:V
 let g:airline#themes#nord#palette.visual.airline_warning = s:VWarn
 let g:airline#themes#nord#palette.visual.airline_error = s:VError
 
-let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
-let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
-let s:IAMiddle = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
+if g:nord_uniform_status_lines == 0
+  let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+  let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+  let s:IAMiddle = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
+else
+  let s:IAMain = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
+  let s:IARight = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
+  let s:IAMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+endif
 let s:IAWarn = [s:nord1_gui, s:nord13_gui, s:nord3_term, s:nord13_term]
 let s:IAError = [s:nord0_gui, s:nord11_gui, s:nord1_term, s:nord11_term]
 let g:airline#themes#nord#palette.inactive = airline#themes#generate_color_map(s:IAMain, s:IARight, s:IAMiddle)

--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -78,13 +78,11 @@ let g:airline#themes#nord#palette.visual = airline#themes#generate_color_map(s:V
 let g:airline#themes#nord#palette.visual.airline_warning = s:VWarn
 let g:airline#themes#nord#palette.visual.airline_error = s:VError
 
+let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
+let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 if g:nord_uniform_status_lines == 0
-  let s:IAMain = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
-  let s:IARight = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
   let s:IAMiddle = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
 else
-  let s:IAMain = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
-  let s:IARight = [s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term]
   let s:IAMiddle = [s:nord5_gui, s:nord3_gui, s:nord5_term, s:nord3_term]
 endif
 let s:IAWarn = [s:nord1_gui, s:nord13_gui, s:nord3_term, s:nord13_term]

--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -32,7 +32,7 @@ let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
 let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
 
 let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
-let s:p.inactive.middle = [ [ s:nord5, s:nord1 ] ]
+let s:p.inactive.middle = g:nord_uniform_status_lines == 0 ? [ [ s:nord5, s:nord1 ] ] : [ [ s:nord5, s:nord3 ] ]
 let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 
 let s:p.insert.left = [ [ s:nord1, s:nord6 ], [ s:nord5, s:nord1 ] ]


### PR DESCRIPTION
> Fixes #168
> Related to #58

The included theme bundles do not support the implementated feature #58, which allows to change the background color of the status bar (`StatusLine`) group to nord3.

This PR will add support for these bundles.

### lightline.vim
**Before**:
<img width="1680" alt="Screen Shot 2019-07-14 at 22 42 35" src="https://user-images.githubusercontent.com/16728775/61186256-340fb900-a69e-11e9-8887-b153b869de5c.png">

**After**:
<img width="1680" alt="Screen Shot 2019-07-14 at 22 42 56" src="https://user-images.githubusercontent.com/16728775/61186259-38d46d00-a69e-11e9-9d2f-bf72f6b2af14.png">

### vim-airline
**Before**:
<img width="1680" alt="Screen Shot 2019-07-14 at 22 44 37" src="https://user-images.githubusercontent.com/16728775/61186260-3f62e480-a69e-11e9-9fcd-48b53307d97a.png">

**After**:
<img width="1680" alt="Screen Shot 2019-07-14 at 22 45 02" src="https://user-images.githubusercontent.com/16728775/61186263-438f0200-a69e-11e9-8028-eee21ff3ceb0.png">


NOTE: for airline I had to change the background colors of the groups on the right side to nord1 so that it adds contrast between these groups and the middle section.