### PR TITLE
Plugin support for `vim-startify`

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -609,6 +609,17 @@ call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
 " > kshenoy/vim-signature
 call s:hi("SignatureMarkText", s:nord8_gui, "", s:nord8_term, "", "", "")
 
+" vim-startify
+" > mhinz/vim-startify
+call s:hi("StartifyFile", s:nord6_gui, "", s:nord6_term, "", "", "")
+call s:hi("StartifyFooter", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("StartifyHeader", s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("StartifyNumber", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("StartifyPath", s:nord8_gui, "", s:nord8_term, "", "", "")
+hi! link StartifyBracket Delimiter
+hi! link StartifySlash Normal
+hi! link StartifySpecial Comment
+
 "+--- Languages ---+
 " Haskell
 " > neovimhaskell/haskell-vim


### PR DESCRIPTION
Closes #159 

This PR adds the custom highlight groups of the [vim-startify][p] plugin to adapt to Nord's style.

<img src="https://user-images.githubusercontent.com/7836623/66123513-86e47700-e5e2-11e9-9fa8-e41dc07efc82.png">

[p]: https://github.com/mhinz/vim-startify
