### PR TITLE
Add support for vim-clap

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -610,12 +610,9 @@ hi! link CtrlPBufferHid Normal
 
 " vim-clap
 " > liuchengxu/vim-clap
-hi! link ClapInput Pmenu
+call s:hi("ClapDir", s:nord4_gui, "", "", "", "", "")
 call s:hi("ClapDisplay", s:nord4_gui, s:nord1_gui, "", s:nord1_term, "", "")
-hi! link ClapPreview Pmenu
-hi! link ClapCurrentSelection PmenuSel
-call s:hi("ClapSelected", "", "", "", "", s:underline, "")
-call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("ClapFile", s:nord4_gui, "", "", "NONE", "", "")
 call s:hi("ClapMatches", s:nord8_gui, "", s:nord8_term, "", "", "")
 call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
@@ -626,18 +623,20 @@ let s:clap_matches = [
         \ [s:nord9_gui,  s:nord9_term] ,
         \ [s:nord10_gui, s:nord10_term] ,
         \ ]
-
-for s:i in range(1,12)
-  let clap_match_color = s:clap_matches[s:i % len(s:clap_matches) - 1]
-  call s:hi("ClapMatches" . s:i, clap_match_color[0], "", clap_match_color[1], "", "", "")
-  call s:hi("ClapFuzzyMatches" . s:i, clap_match_color[0], "", clap_match_color[1], "", "", "")
+for s:nord_clap_match_i in range(1,12)
+  let clap_match_color = s:clap_matches[s:nord_clap_match_i % len(s:clap_matches) - 1]
+  call s:hi("ClapMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
+  call s:hi("ClapFuzzyMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
 endfor
+unlet s:nord_clap_match_i
 
-call s:hi("ClapFile", s:nord4_gui, "", "", "", "NONE", "")
-call s:hi("ClapDir", s:nord4_gui, "", "", "", s:italic, "")
-hi! link ClapProviderId Type
-hi! link ClapProviderColon Type
+hi! link ClapCurrentSelection PmenuSel
+hi! link ClapCurrentSelectionSign ClapSelectedSign
+hi! link ClapInput Pmenu
+hi! link ClapPreview Pmenu
 hi! link ClapProviderAbout ClapDisplay
+hi! link ClapProviderColon Type
+hi! link ClapProviderId Type
 
 " vim-plug
 " > junegunn/vim-plug

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -572,9 +572,6 @@ call s:hi("LSPDiagnosticsWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LSPDiagnosticsError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LSPDiagnosticsInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
 call s:hi("LSPDiagnosticsHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
-hi! link LSPReferenceText CursorColumn
-hi! link LSPReferenceRead LSPReferenceText
-hi! link LSPReferenceWrite LSPReferenceText
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -605,7 +605,7 @@ hi! link CtrlPBufferHid Normal
 " > liuchengxu/vim-clap
 call s:hi("ClapInput", s:nord4_gui, s:nord2_gui, s:nord3_term, s:nord1_term, "", "")
 call s:hi("ClapDisplay", s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term, "", "")
-call s:hi("ClapPreview", "", s:nord1_gui, "", s:nord1_term, "", "")
+call s:hi("ClapPreview", s:nord4_gui, s:nord2_gui, s:nord3_term, s:nord1_term, "", "")
 call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:underline, "")
 call s:hi("ClapCurrentSelection", s:nord7_gui, "", s:nord8_term, "", s:bold, "")
 call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -617,6 +617,9 @@ hi! link ClapCurrentSelection PmenuSel
 call s:hi("ClapSelected", "", "", "", "", s:underline, "")
 call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("ClapMatches", s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
+call s:hi("ClapSelectedSign", s:nord9_gui, "", s:nord9_term, "", "", "")
 
 let s:clap_matches = [
         \ [s:nord8_gui,  s:nord8_term] ,

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -601,6 +601,49 @@ hi! link NERDTreeHelp Comment
 hi! link CtrlPMatch Keyword
 hi! link CtrlPBufferHid Normal
 
+" vim-clap
+" > liuchengxu/vim-clap
+call s:hi("ClapInput", s:nord4_gui, s:nord2_gui, s:nord3_term, s:nord1_term, "", "")
+call s:hi("ClapDisplay", s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term, "", "")
+call s:hi("ClapPreview", "", s:nord1_gui, "", s:nord1_term, "", "")
+call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:underline, "")
+call s:hi("ClapCurrentSelection", s:nord7_gui, "", s:nord8_term, "", s:bold, "")
+call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
+let clap_matches = [
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ ]
+let idx = 1
+for g in clap_matches
+  call s:hi("ClapMatches" . idx, g[0], "", g[1], "", "", "")
+  let idx += 1
+endfor
+let clap_fuzzy_matches = [
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ [s:nord11_gui, s:nord11_term] ,
+        \ [s:nord13_gui, s:nord13_term] ,
+        \ [s:nord14_gui, s:nord14_term] ,
+        \ ]
+let idx = 1
+for g in clap_fuzzy_matches
+  call s:hi("ClapFuzzyMatches" . idx, g[0], "", g[1], "", "", "")
+  let idx += 1
+endfor
+
 " vim-plug
 " > junegunn/vim-plug
 call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -572,7 +572,9 @@ call s:hi("LSPDiagnosticsWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LSPDiagnosticsError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LSPDiagnosticsInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
 call s:hi("LSPDiagnosticsHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
-
+hi! link LSPReferenceText CursorColumn
+hi! link LSPReferenceRead LSPReferenceText
+hi! link LSPReferenceWrite LSPReferenceText
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -603,46 +603,31 @@ hi! link CtrlPBufferHid Normal
 
 " vim-clap
 " > liuchengxu/vim-clap
-call s:hi("ClapInput", s:nord4_gui, s:nord2_gui, s:nord3_term, s:nord1_term, "", "")
-call s:hi("ClapDisplay", s:nord5_gui, s:nord1_gui, s:nord5_term, s:nord1_term, "", "")
-call s:hi("ClapPreview", s:nord4_gui, s:nord2_gui, s:nord3_term, s:nord1_term, "", "")
-call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:underline, "")
-call s:hi("ClapCurrentSelection", s:nord7_gui, "", s:nord8_term, "", s:bold, "")
+hi! link ClapInput Pmenu
+call s:hi("ClapDisplay", s:nord4_gui, s:nord1_gui, "", s:nord1_term, "", "")
+hi! link ClapPreview Pmenu
+hi! link ClapCurrentSelection PmenuSel
+call s:hi("ClapSelected", "", "", "", "", s:underline, "")
 call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
-let clap_matches = [
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
+call s:hi("ClapMatches", s:nord8_gui, "", s:nord8_term, "", "", "")
+
+let s:clap_matches = [
+        \ [s:nord8_gui,  s:nord8_term] ,
+        \ [s:nord9_gui,  s:nord9_term] ,
+        \ [s:nord10_gui, s:nord10_term] ,
         \ ]
-let idx = 1
-for g in clap_matches
-  call s:hi("ClapMatches" . idx, g[0], "", g[1], "", "", "")
-  let idx += 1
+
+for s:i in range(1,12)
+  let clap_match_color = s:clap_matches[s:i % len(s:clap_matches) - 1]
+  call s:hi("ClapMatches" . s:i, clap_match_color[0], "", clap_match_color[1], "", "", "")
+  call s:hi("ClapFuzzyMatches" . s:i, clap_match_color[0], "", clap_match_color[1], "", "", "")
 endfor
-let clap_fuzzy_matches = [
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ [s:nord11_gui, s:nord11_term] ,
-        \ [s:nord13_gui, s:nord13_term] ,
-        \ [s:nord14_gui, s:nord14_term] ,
-        \ ]
-let idx = 1
-for g in clap_fuzzy_matches
-  call s:hi("ClapFuzzyMatches" . idx, g[0], "", g[1], "", "", "")
-  let idx += 1
-endfor
+
+call s:hi("ClapFile", s:nord4_gui, "", "", "", "NONE", "")
+call s:hi("ClapDir", s:nord4_gui, "", "", "", s:italic, "")
+hi! link ClapProviderId Type
+hi! link ClapProviderColon Type
+hi! link ClapProviderAbout ClapDisplay
 
 " vim-plug
 " > junegunn/vim-plug


### PR DESCRIPTION
This adds highlights for [vim-clap](https://github.com/liuchengxu/vim-clap)

<img width="1068" alt="clap" src="https://user-images.githubusercontent.com/762115/69010198-984ccd00-095d-11ea-956c-01d7aa9d832a.png">
