### PR TITLE
Dim Lighline Colors for Inactive Window

### DIFF
--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -31,7 +31,7 @@ let s:p.normal.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
 let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
 
-let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
+let s:p.inactive.left =  [ [ s:nord8, s:nord1 ], [ s:nord5, s:nord1 ] ]
 let s:p.inactive.middle = [ [ s:nord5, s:nord1 ] ]
 let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 


### PR DESCRIPTION
Reversed the colors of lightline status bar of the inactive window. This
helps with knowing immediately which window is active. Otherwise, it
is hard to tell from the colors which window is active and which is
inactive.