### PR TITLE
Improve Elixir syntax highlight for modules and atoms

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -395,6 +395,10 @@ hi! link diffAdded DiffAdd
 hi! link diffChanged DiffChange
 hi! link diffRemoved DiffDelete
 
+call s:hi("elixirModuleDeclaration", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("elixirAlias", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("elixirAtom", s:nord6_gui, "", s:nord6_term, "", s:bold, "")
+
 call s:hi("gitconfigVariable", s:nord7_gui, "", s:nord7_term, "", "", "")
 
 call s:hi("goBuiltins", s:nord7_gui, "", s:nord7_term, "", "", "")


### PR DESCRIPTION
Related to: https://github.com/arcticicestudio/nord-visual-studio-code/issues/165

Before it was like this:

![Screenshot from 2019-12-01 19-02-28](https://user-images.githubusercontent.com/27698968/69917330-4764ca80-146d-11ea-8579-850e9704f355.png)

After this change:

![Screenshot from 2019-12-01 19-03-13](https://user-images.githubusercontent.com/27698968/69917337-55b2e680-146d-11ea-8a2d-35a56eac67ce.png)
