### PR TITLE
Add support for nested quotes, URLs, and email addresses in mail

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -684,3 +684,13 @@ hi! link VimwikiList markdownListMarker
 " YAML
 " > stephpy/vim-yaml
 call s:hi("yamlKey", s:nord7_gui, "", s:nord7_term, "", "", "")
+
+" Mail
+call <sid>hi("mailQuoted1",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailQuoted2",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailQuoted3",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailQuoted4",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailQuoted5",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailQuoted6",  s:nord3_gui, "", s:nord3_term, "", "", "")
+call <sid>hi("mailURL",      s:nord8_gui, "", s:nord8_term, "", "", "")
+call <sid>hi("mailEmail",    s:nord8_gui, "", s:nord8_term, "", "", "")


### PR DESCRIPTION
After moving to Nord from Base 16 Tomorrow Night I noticed that nested quotes and URLs were not properly colored when editing mail. I have copied [the definitions from my previous theme](https://github.com/chriskempson/base16-vim/blob/master/colors/base16-tomorrow-night.vim#L335) and changed the colors to what I think are the Nord-appropriate values. Nord 3 is used for comments, which is similar to a quote in mail. Nord 8 is used for Markdown link text, which is similar to URLs and email addresses in mail.