### PR TITLE
Auto set cursorline option when line number background config is active

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -221,6 +221,7 @@ call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0
   call s:hi("CursorLineNr", s:nord4_gui, s:nord0_gui, "NONE", "", "NONE", "")
 else
+  set cursorline
   call s:hi("CursorLineNr", s:nord4_gui, s:nord1_gui, "NONE", s:nord1_term, "NONE", "")
 endif
 call s:hi("Folded", s:nord3_gui, s:nord1_gui, s:nord3_term, s:nord1_term, s:bold, "")


### PR DESCRIPTION
Resolves #141 

auto set cursorline when
``` vimrc
let g:nord_cursor_line_number_background = 1
```
to reslove [issue141](https://github.com/arcticicestudio/nord-vim/issues/141) that don't show properly at some point