### PR TITLE
Add nvim-lsp support

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -566,6 +566,14 @@ call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")
 call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
+" Nvim LSP
+" > neovim/nvim-lsp
+call s:hi("LSPDiagnosticsWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("LSPDiagnosticsError" , s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("LSPDiagnosticsInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("LSPDiagnosticsHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
+
+
 " GitGutter
 " > airblade/vim-gitgutter
 call s:hi("GitGutterAdd", s:nord14_gui, "", s:nord14_term, "", "", "")


### PR DESCRIPTION
This adds highlighting for the build-in neovim language server (as can be seen in the lsp help file of neovim) 

excerpt:

```
================================================================================
LSP HIGHLIGHT                                                    *lsp-highlight*

                                                        *hl-LspDiagnosticsError*
LspDiagnosticsError       used for "Error" diagnostic virtual text
                                                      *hl-LspDiagnosticsWarning*
LspDiagnosticsWarning     used for "Warning" diagnostic virtual text
                                                  *hl-LspDiagnosticsInformation*
LspDiagnosticInformation  used for "Information" diagnostic virtual text
                                                         *hl-LspDiagnosticsHint*
LspDiagnosticHint         used for "Hint" diagnostic virtual text
                                                           *hl-LspReferenceText*
LspReferenceText          used for highlighting "text" references
                                                           *hl-LspReferenceRead*
LspReferenceRead          used for highlighting "read" references
                                                          *hl-LspReferenceWrite*
LspReferenceWrite         used for highlighting "write" references

```

I used the same highlighting as Coc.nvim to ensure consistency.
