### PR TITLE
Add coc error/warning highlight

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -561,6 +561,8 @@ call s:hi("ALEError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
 
 " Coc
 " > neoclide/coc
+call s:hi("CocWarningHighlight" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+call s:hi("CocErrorHighlight" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
 call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")


### PR DESCRIPTION
fixes issue where there is no indicator where in the line the warning/error is (only indicated in the gutter)

this is synonymous with the Ale warning/error highlights and adds the undercurl to them