### PR TITLE
Fix issue #215

### DIFF
--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -32,7 +32,11 @@ let s:p.normal.warning = [ [ s:nord1, s:nord13 ] ]
 let s:p.normal.error = [ [ s:nord1, s:nord11 ] ]
 
 let s:p.inactive.left =  [ [ s:nord1, s:nord8 ], [ s:nord5, s:nord1 ] ]
+if !exists('g:nord_uniform_status_lines')
+let s:p.inactive.middle = [ [ s:nord5, s:nord1 ] ]
+else
 let s:p.inactive.middle = g:nord_uniform_status_lines == 0 ? [ [ s:nord5, s:nord1 ] ] : [ [ s:nord5, s:nord3 ] ]
+endif
 let s:p.inactive.right = [ [ s:nord5, s:nord1 ], [ s:nord5, s:nord1 ] ]
 
 let s:p.insert.left = [ [ s:nord1, s:nord6 ], [ s:nord5, s:nord1 ] ]


### PR DESCRIPTION
Now when user load `nord-vim` before `lightline`, but choose to use a colorscheme other than `nord` and the lightline theme `nord`, the lightline theme is loaded correctly.