### PR TITLE
Improve php highlighting

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -469,9 +469,12 @@ hi! link markdownHeadingDelimiter Keyword
 call s:hi("perlPackageDecl", s:nord7_gui, "", s:nord7_term, "", "", "")
 
 call s:hi("phpClasses", s:nord7_gui, "", s:nord7_term, "", "", "")
+call s:hi("phpClass", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("phpDocTags", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link phpDocCustomTags phpDocTags
 hi! link phpMemberSelector Keyword
+hi! link phpMethod Function
+hi! link phpFunction Function
 
 call s:hi("podCmdText", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("podVerbatimLine", s:nord4_gui, "", "NONE", "", "", "")


### PR DESCRIPTION
I added highlight for some groups in php, to better match highlighting in vscode, because I think highlight in vscode is nice.

### Here's the comparison before (left = neovim, right = vscode):
![nord-fix-previous](https://user-images.githubusercontent.com/10344542/88252422-491f1f00-ccd8-11ea-8b27-bf88457442ce.png)

### Here's the comparison after:
![nord-fix-after](https://user-images.githubusercontent.com/10344542/88252441-5b995880-ccd8-11ea-807c-9f8300295b10.png)


Still cannot highlight some element, e.g trait `use`, `$this` keyword, because missing highlight group for those, probably need additional syntax definition plugin for php?