### PR TITLE
Add support for pandoc

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -677,6 +677,19 @@ hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword
 hi! link jsRegexpString SpecialChar
 
+" Pandoc
+" > vim-pandoc/vim-pandoc-syntax
+call s:hi("pandocAtxHeader", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
+call s:hi("pandocPipeTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
+call s:hi("pandocPipeTableHeader", s:nord3_gui, "", s:nord3_term, "", "", "")
+call s:hi("pandocTableHeaderWord", s:nord9_gui, "", s:nord9_term, "", "", "")
+call s:hi("pandocCiteAnchor", s:nord12_gui, "", s:nord12_term, "", "", "")
+call s:hi("pandocCiteKey", s:nord15_gui, "", s:nord15_term, "", "", "")
+call s:hi("pandocReferenceDefinition", s:nord6_gui, "", s:nord6_term, "", "", "")
+call s:hi("pandocFootnoteDef", s:nord9_gui, "", s:nord9_term, "", "", "")
+call s:hi("pandocDefinitionBlockTerm", s:nord12_gui, "", s:nord12_term, "", s:bold, "")
+call s:hi("pandocDefinitionBlock", s:nord9_gui, "", s:nord9_term, "", s:italic, "")
+
 " TypeScript
 " > HerringtonDarkholme/yats.vim
 call s:hi("typescriptBOMWindowMethod", s:nord8_gui, "", s:nord8_term, "", s:italic, "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -679,16 +679,28 @@ hi! link jsRegexpString SpecialChar
 
 " Pandoc
 " > vim-pandoc/vim-pandoc-syntax
-call s:hi("pandocAtxHeader", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
-call s:hi("pandocPipeTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
-call s:hi("pandocPipeTableHeader", s:nord3_gui, "", s:nord3_term, "", "", "")
-call s:hi("pandocTableHeaderWord", s:nord9_gui, "", s:nord9_term, "", "", "")
-call s:hi("pandocCiteAnchor", s:nord12_gui, "", s:nord12_term, "", "", "")
-call s:hi("pandocCiteKey", s:nord15_gui, "", s:nord15_term, "", "", "")
-call s:hi("pandocReferenceDefinition", s:nord6_gui, "", s:nord6_term, "", "", "")
-call s:hi("pandocFootnoteDef", s:nord9_gui, "", s:nord9_term, "", "", "")
-call s:hi("pandocDefinitionBlockTerm", s:nord12_gui, "", s:nord12_term, "", s:bold, "")
-call s:hi("pandocDefinitionBlock", s:nord9_gui, "", s:nord9_term, "", s:italic, "")
+call s:hi("pandocDefinitionBlockTerm", s:nord7_gui, "", s:nord7_term, "", s:italic, "")
+call s:hi("pandocTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
+hi! link pandocAtxHeader markdownH1
+hi! link pandocBlockQuote markdownBlockquote
+hi! link pandocCiteAnchor Operator
+hi! link pandocCiteKey pandocReferenceLabel
+hi! link pandocDefinitionBlockMark Operator
+hi! link pandocEmphasis markdownItalic
+hi! link pandocFootnoteID pandocReferenceLabel
+hi! link pandocFootnoteIDHead markdownLinkDelimiter
+hi! link pandocFootnoteIDTail pandocFootnoteIDHead
+hi! link pandocGridTableDelims pandocTableDelims
+hi! link pandocGridTableHeader pandocTableDelims
+hi! link pandocOperator Operator
+hi! link pandocPipeTableDelims pandocTableDelims
+hi! link pandocReferenceDefinition pandocReferenceLabel
+hi! link pandocReferenceLabel markdownLinkText
+hi! link pandocReferenceURL markdownUrl
+hi! link pandocSimpleTableHeader pandocAtxHeader
+hi! link pandocStrong markdownBold
+hi! link pandocTableHeaderWord pandocAtxHeader
+hi! link pandocUListItemBullet Operator
 
 " TypeScript
 " > HerringtonDarkholme/yats.vim


### PR DESCRIPTION
The current version of `nord-vim` does not have support for most syntax elements from the `vim-pandoc-syntax` package (#207):

![before](https://user-images.githubusercontent.com/579329/89132103-a9d00800-d4df-11ea-9563-80d79d4ab5f9.png)

I have added support for these groups - notably, this solves the issues with `Conceal` (notably #211). This is the result with the additional syntax groups:

![after](https://user-images.githubusercontent.com/579329/89132102-a9d00800-d4df-11ea-880a-6a3295d33bea.png)
