### PR TITLE
Add support for Julia syntax

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -675,6 +675,14 @@ hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword
 hi! link jsRegexpString SpecialChar
 
+" Julia
+" > JuliaEditorSupport/julia-vim
+hi! link JuliaSymbol Function
+hi! link JuliaStringVarsPla SpecialChar
+hi! link JuliaStringVarsPar SpecialChar
+call s:hi("juliaConstBool", s:nord12_gui, "", s:nord12_term, "", s:italic, "")
+call s:hi("juliaBlKeyword", s:nord15_gui, "", s:nord15_term, "", s:italic, "")
+
 " TypeScript
 " > HerringtonDarkholme/yats.vim
 call s:hi("typescriptBOMWindowMethod", s:nord8_gui, "", s:nord8_term, "", s:italic, "")


### PR DESCRIPTION
The theme has limited support for important Julia syntax:

![before](https://user-images.githubusercontent.com/579329/89132502-9f633d80-d4e2-11ea-955a-4d6b109e4d92.png)

This is the result after:

![after](https://user-images.githubusercontent.com/579329/89132501-9ecaa700-d4e2-11ea-87f0-5b052a55187c.png)
