### PR TITLE
Add public API function to get Nord colors

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -77,6 +77,7 @@ function! NordPalette() abort
   for color in range(16)
     execute 'let ret["nord'.color.'"] = s:nord'.color.'_gui'
   endfor
+  let ret["nord3_bright"] = s:nord3_gui_bright
   return ret
 endfunction
 

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -72,6 +72,14 @@ let s:nord3_gui_brightened = [
   \ "#7b88a1",
 \ ]
 
+function! NordPalette() abort
+  let ret = {}
+  for color in range(16)
+    execute 'let ret["nord'.color.'"] = s:nord'.color.'_gui'
+  endfor
+  return ret
+endfunction
+
 if !exists("g:nord_bold")
   let g:nord_bold = 1
 endif

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -72,15 +72,6 @@ let s:nord3_gui_brightened = [
   \ "#7b88a1",
 \ ]
 
-function! NordPalette() abort
-  let ret = {}
-  for color in range(16)
-    execute 'let ret["nord'.color.'"] = s:nord'.color.'_gui'
-  endfor
-  let ret["nord3_bright"] = s:nord3_gui_bright
-  return ret
-endfunction
-
 if !exists("g:nord_bold")
   let g:nord_bold = 1
 endif
@@ -776,3 +767,17 @@ hi! link VimwikiList markdownListMarker
 " YAML
 " > stephpy/vim-yaml
 call s:hi("yamlKey", s:nord7_gui, "", s:nord7_term, "", "", "")
+
+"+------------+
+"+ Public API +
+"+------------+
+"+--- Functions ---+
+
+function! NordPalette() abort
+  let ret = {}
+  for color in range(16)
+    execute 'let ret["nord'.color.'"] = s:nord'.color.'_gui'
+  endfor
+  let ret["nord3_bright"] = s:nord3_gui_bright
+  return ret
+endfunction


### PR DESCRIPTION
This way a user who wants to use the colors of the Nord theme without having to copy hex-codes from the website.

This way adding/modifying highlight groups could be done like this:
```vim
let colors = NordPalette()
execute 'hi MyGroup guifg='.colors.nord3
```