### PR TITLE
Add support for the "nathanaelkane/vim-indent-guides" plugin

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -643,6 +643,11 @@ hi! link ClapProviderAbout ClapDisplay
 hi! link ClapProviderColon Type
 hi! link ClapProviderId Type
 
+" vim-indent-guides
+" > nathanaelkane/vim-indent-guides
+call s:hi("IndentGuidesEven", "", s:nord1_gui, "", s:nord1_term, "", "")
+call s:hi("IndentGuidesOdd", "", s:nord2_gui, "", s:nord3_term, "", "")
+
 " vim-plug
 " > junegunn/vim-plug
 call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")


### PR DESCRIPTION
Resolves #186

The even and odd highlighting blocks using `nord1` and `nord2` (`nord3`in terminal mode) to provide a subtle and non-disturbing style.

Note that the [custom theme colors][nathanaelkane/vim-indent-guides#custom_color] are only applied when the `indent_guides_auto_colors` variable has been set to `0`:

```vim
let g:indent_guides_auto_colors = 0
```

<p align="center"><strong>Before</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/95505941-71511c80-09af-11eb-898a-4c7e6396c4d4.png" /></p>

<p align="center"><strong>After</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/95505930-6eeec280-09af-11eb-84bb-2e0b0265b525.png" /></p>

[nathanaelkane/vim-indent-guides#custom_color]: https://github.com/nathanaelkane/vim-indent-guides#setting-custom-indent-colors