### PR TITLE
Fix Toml's table and table array headers

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -529,6 +529,9 @@ hi! link shDerefVar Identifier
 hi! link sqlKeyword Keyword
 hi! link sqlSpecial Keyword
 
+call s:hi("tomlTable", s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("tomlTableArray", s:nord8_gui, "", s:nord8_term, "", "", "")
+
 call s:hi("vimAugroup", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("vimMapRhs", s:nord7_gui, "", s:nord7_term, "", "", "")
 call s:hi("vimNotation", s:nord7_gui, "", s:nord7_term, "", "", "")


### PR DESCRIPTION
Fixes #232 

From issue:

> vim-toml uses Title style for those headers so this problem is similar to asciidoc's `asciidocOneLineTitle`.

Because of that I have copied the same style as used by `asciidocOneLineTitle` for `tomlTable` and `tomlTableArray`.