### PR TITLE
Add Lualine support to nord-vim

### DIFF
--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -20,49 +20,49 @@ return {
   normal = {
     a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   },
   insert = {
     a = {bg = colors.nord6, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   },
   visual = {
     a = {bg = colors.nord7, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   },
   replace = {
     a = {bg = colors.nord13, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   },
   command = {
     a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   },
   inactive = {
     a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
     b = {bg = colors.nord1, fg = colors.nord5},
-    c = {bg = colors.nord3, fg = colors.nord5}
+    c = {bg = colors.nord3, fg = colors.nord5},
     x = {bg = colors.nord3, fg = colors.nord5},
     y = {bg = colors.nord1, fg = colors.nord5},
-    z = {bg = colors.nord3, fg = colors.nord5}
+    z = {bg = colors.nord1, fg = colors.nord5}
   }
 }

--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -1,0 +1,68 @@
+local colors = {
+  nord0        = '#2e3440',
+  nord1        = '#3b4252',
+  nord2        = '#434c5e',
+  nord3        = '#4c566a',
+  nord4        = '#d8dee9',
+  nord5        = '#e5e9f0',
+  nord6        = '#eceff4',
+  nord7        = '#8fbcbb',
+  nord8        = '#88c0d0',
+  nord9        = '#81a1c1',
+  nord10       = '#5e81ac',
+  nord11       = '#bf616a',
+  nord12       = '#d08770',
+  nord13       = '#ebcb8b',
+  nord14       = '#a3be8c',
+  nord15       = '#b48ead',
+}
+return {
+  normal = {
+    a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  },
+  insert = {
+    a = {bg = colors.nord6, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  },
+  visual = {
+    a = {bg = colors.nord7, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  },
+  replace = {
+    a = {bg = colors.nord13, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  },
+  command = {
+    a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  },
+  inactive = {
+    a = {bg = colors.nord8, fg = colors.nord1, gui = 'bold'},
+    b = {bg = colors.nord1, fg = colors.nord5},
+    c = {bg = colors.nord3, fg = colors.nord5}
+    x = {bg = colors.nord3, fg = colors.nord5},
+    y = {bg = colors.nord1, fg = colors.nord5},
+    z = {bg = colors.nord3, fg = colors.nord5}
+  }
+}


### PR DESCRIPTION
Adds support for [Lualine](https://github.com/hoob3rt/lualine.nvim), a Neovim statusline plugin written in Lua. While the theme tries to stay as close as possible to the existing Lightline theme, the filename section uses `nord3` as the background rather than `nord1` due to that section also determining the color of the background. 

Screenshots are attached of the theme in action:

![swappy-20210705_223441](https://user-images.githubusercontent.com/20235646/124502997-3d8e1080-dde2-11eb-9e11-25c876435905.png)

![swappy-20210705_223421](https://user-images.githubusercontent.com/20235646/124503000-3ebf3d80-dde2-11eb-86c4-3e8ad87327a6.png)

![swappy-20210705_223346](https://user-images.githubusercontent.com/20235646/124503002-3f57d400-dde2-11eb-92c9-f07d94b2f7d5.png)

![swappy-20210705_223327](https://user-images.githubusercontent.com/20235646/124503003-3ff06a80-dde2-11eb-93f5-1348114e019b.png)
