### PR TITLE
add support for Lsp codelens

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -574,6 +574,7 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " Neovim LSP
 " > neovim/nvim-lspconfig
+call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", s:italicize_comments, "")
 call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -574,7 +574,6 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " Neovim LSP
 " > neovim/nvim-lspconfig
-call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", s:italicize_comments, "")
 call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
@@ -583,6 +582,7 @@ call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, ""
 call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
 call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
 call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+hi! link LspCodeLens Comment
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -574,6 +574,7 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " Neovim LSP
 " > neovim/nvim-lspconfig
+call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", s:italicize_comments, "")
 call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
@@ -582,7 +583,6 @@ call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, ""
 call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
 call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
 call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
-hi! link LspCodeLens Comment
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -574,7 +574,7 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " Neovim LSP
 " > neovim/nvim-lspconfig
-call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", s:italicize_comments, "")
+call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")


### PR DESCRIPTION
code lenses are currently highlighted with the default color. This change adjusts it to make it less visually intrusive like comments. docs: https://neovim.io/doc/user/lsp.html#hl-LspCodeLens

Before:
<img width="622" alt="125170561-cc6aa680-e1af-11eb-9a21-98bbdd62e821" src="https://user-images.githubusercontent.com/5249233/125171712-d1caef80-e1b5-11eb-8a40-95d7e2a79bbd.png">

After:
<img width="620" alt="Screenshot 2021-07-10 at 19 28 57" src="https://user-images.githubusercontent.com/5249233/125171722-da232a80-e1b5-11eb-9073-5fb3795d1136.png">


It is based on the VS code highlighting:
<img width="442" alt="Screenshot 2021-07-10 at 19 10 09" src="https://user-images.githubusercontent.com/5249233/125171724-e0b1a200-e1b5-11eb-8062-a64dacb1e06f.png">
