### PR TITLE
Improve readability of C language constants

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -351,6 +351,7 @@ hi! link awkVariables Identifier
 call s:hi("cIncluded", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link cOperator Operator
 hi! link cPreCondit PreCondit
+hi! link cConstant Exception
 
 call s:hi("cmakeGeneratorExpression", s:nord10_gui, "", s:nord10_term, "", "", "")
 

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -351,7 +351,7 @@ hi! link awkVariables Identifier
 call s:hi("cIncluded", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link cOperator Operator
 hi! link cPreCondit PreCondit
-hi! link cConstant Exception
+hi! link cConstant Type
 
 call s:hi("cmakeGeneratorExpression", s:nord10_gui, "", s:nord10_term, "", "", "")
 


### PR DESCRIPTION
This commits makes constant stand out. This is important in C, since *interesting* things are usually happening in their proximity, like checking/returning an error, passing particular values/flags to functions, …

Before:
![before](https://user-images.githubusercontent.com/325724/147776107-5ac10b51-fbd1-41f9-b254-4b2f4a9ca876.png)

After:
![after](https://user-images.githubusercontent.com/325724/147776106-fb39fbc9-36eb-4db4-b8dc-b217b9ac6246.png)
