### PR TITLE
Add support for LSP textDocument/documentHighlight

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -594,6 +594,9 @@ if has("nvim-0.5")
   call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
   call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
   call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+  call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
+  call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
+  call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
 endif
 
 " GitGutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -226,6 +226,11 @@ call s:hi("DiagnosticUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "und
 call s:hi("DiagnosticUnderlineInfo" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
 call s:hi("DiagnosticUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
 
+"+- Neovim DocumentHighlight -+
+call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
+call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
+call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
+
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0
@@ -594,9 +599,6 @@ if has("nvim-0.5")
   call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
   call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
   call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
-  call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
-  call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
-  call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
 endif
 
 " GitGutter


### PR DESCRIPTION
Allows nord to properly handle the highlight groups associated with the
method textDocument/documentHightlight in neovim.
- Neovim docs: https://github.com/neovim/neovim/blob/b0993bdc45cad621976b9cc2c6ce7ee29dbeb93d/runtime/doc/lsp.txt#L427

See it in action:
![Screen Recording 2022-01-02 at 17 50 35](https://user-images.githubusercontent.com/59028844/147889666-b8da789e-d8c5-4cc7-96ab-97c9b56ba592.gif)