### PR TITLE
Add support for LSPSignatureActiveParameter

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -231,6 +231,9 @@ call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
 call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
 call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
 
+"+- Neovim LspSignatureHelp -+
+call s:hi("LspSignatureActiveParameter", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
+
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0


### PR DESCRIPTION
Currently when calling `vim.lsp.buf.signature_help` on a given
function/method nord does not highlight or differentiate the active parameter.

This PR adds an accent color (**`nord8`**) and an **underline** to the current
active parameter making it stand out.

Highlight group docs: https://github.com/neovim/neovim/blob/70db972e5fbcab39946ad8ac05472a693cf65b68/runtime/doc/lsp.txt#L456-L459

See it in action:
**Before**:
![nord-before-zoom](https://user-images.githubusercontent.com/59028844/150651620-9e3a78b1-a10f-42ee-a639-7155a54fe45e.png)

**After**:
![nord-after-zoom](https://user-images.githubusercontent.com/59028844/150651619-67d21428-2193-4c96-8f70-9c87997b40be.png)

**Live**:
![nord-1](https://user-images.githubusercontent.com/59028844/150651458-6db090fc-6d9a-4e48-9b44-55c933fe426d.gif)