### PR TITLE
Drop `syntax reset` on modern vim version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@
 
 <!--lint disable no-duplicate-headings-->
 
+# 0.17.0
+
+![Release Date: 2021-07-10](https://img.shields.io/static/v1.svg?style=flat-square&label=Release%20Date&message=2021-07-10&colorA=4c566a&colorB=88c0d0) [![Project Board](https://img.shields.io/static/v1.svg?style=flat-square&label=Project%20Board&message=0.17.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/projects/23) [![Milestone](https://img.shields.io/static/v1.svg?style=flat-square&label=Milestone&message=0.17.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/milestone/19)
+
+⇅ [Show all commits][gh-compare-tag-v0.16.0_v0.17.0]
+
+## Features
+
+### Syntax
+
+<details>
+<summary><strong>Support for <a href="https://github.com/nvim-treesitter/nvim-treesitter" target="_blank" rel="noreferrer"><code>nvim-treesitter/nvim-treesitter</code></a></strong> — #235 ⇄ #253 (⊶ b3e712a9) by <a href="https://github.com/s-u-d-o-e-r" target="_blank" rel="noreferrer">@s-u-d-o-e-r</a> and <a href="https://github.com/mrswats" target="_blank" rel="noreferrer">@mrswats</a></summary>
+
+↠ Neovim [version 0.5][neovim/neovim-v0.5.0] is a long-time awaited update that introduces features like support for [tree-sitter][tree-sitter/tree-sitter] via [nvim-treesitter][nvim-treesitter/nvim-treesitter] and [LSP][neovim-docs-lsp] via [nvim-lspconfig][neovim/nvim-lspconfig].
+Even though Neovim divides more and more from Vim through specific features like first-class Lua support with custom APIs, the highlighting for tree-sitter is achieved through “normal“ syntax highlighting groups. Most of the groups are already [linked by the `nvim-treesitter` plugin by default][nvim-treesitter/nvim-treesitter-blob-90f15d9] so only a few groups have been adjusted for now to fit the Nord style.
+
+⚠️ Note that this is the first iteration and **it is very likely that there will be inconsistencies compared to the current highlighting when using “normal“ Vim plugins per language**. Please **report any problem** you find so that the support for tree-sitter can be improved continuously!
+
+</details>
+
 # 0.16.0
 
 ![Release Date: 2021-06-09](https://img.shields.io/static/v1.svg?style=flat-square&label=Release%20Date&message=2021-06-09&colorA=4c566a&colorB=88c0d0) [![Project Board](https://img.shields.io/static/v1.svg?style=flat-square&label=Project%20Board&message=0.16.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/projects/22) [![Milestone](https://img.shields.io/static/v1.svg?style=flat-square&label=Milestone&message=0.16.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/milestone/18)
@@ -1044,3 +1064,13 @@ otherwise Markdown elements are not parsed and rendered!
 [vim-docs#php_syntax]: https://vimhelp.org/syntax.txt.html#ft%2dphp%2dsyntax
 [vim-pandoc/vim-pandoc-syntax]: https://github.com/vim-pandoc/vim-pandoc-syntax
 [wikip-greek_alphabet]: https://en.wikipedia.org/wiki/Greek_alphabet
+
+<!-- 0.17.0 -->
+
+[gh-compare-tag-v0.16.0_v0.17.0]: https://github.com/arcticicestudio/nord-vim/compare/v0.16.0...v0.17.0
+[neovim-docs-lsp]: https://neovim.io/doc/user/lsp.html
+[neovim/neovim-v0.5.0]: https://github.com/neovim/neovim/releases/tag/v0.5.0
+[neovim/nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
+[nvim-treesitter/nvim-treesitter-blob-90f15d9]: https://github.com/nvim-treesitter/nvim-treesitter/blob/90f15d9/plugin/nvim-treesitter.vim
+[nvim-treesitter/nvim-treesitter]: https://github.com/nvim-treesitter/nvim-treesitter
+[tree-sitter/tree-sitter]: https://github.com/tree-sitter/tree-sitter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@
 
 <!--lint disable no-duplicate-headings-->
 
+# 0.18.0
+
+![Release Date: 2021-09-12](https://img.shields.io/static/v1.svg?style=flat-square&label=Release%20Date&message=2021-09-12&colorA=4c566a&colorB=88c0d0) [![Project Board](https://img.shields.io/static/v1.svg?style=flat-square&label=Project%20Board&message=0.18.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/projects/24) [![Milestone](https://img.shields.io/static/v1.svg?style=flat-square&label=Milestone&message=0.18.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/milestone/20)
+
+⇅ [Show all commits][gh-compare-tag-v0.17.0_v0.18.0]
+
+## Features
+
+### Syntax
+
+<details>
+<summary><strong>Support for <a href="https://github.com/vim-pandoc/vim-pandoc-syntax" target="_blank" rel="noreferrer"><code>vim-pandoc/vim-pandoc-syntax</code></a></strong> — #220 (⊶ 8d8b9bf8) by <a href="https://github.com/tpoisot" target="_blank" rel="noreferrer">@tpoisot</a> and <a href="https://github.com/BirgerNi" target="_blank" rel="noreferrer">@BirgerNi</a></summary>
+
+↠ To improve syntax highlighting for [Pandoc][], support for the [vim-pandoc/vim-pandoc-syntax][] plugin has been implemented.
+Most groups are linked to existing Markdown groups to ensure a consistent style across languages and different plugins.
+
+<p align="center"><img src="https://user-images.githubusercontent.com/7836623/120067101-1f622180-c07a-11eb-81a0-73414e54df55.png" width="75%" /></p>
+
+</details>
+
+### UI
+
+<details>
+<summary><strong>Support for <a href="https://neovim.io/doc/user/lsp.html#lsp-highlight-codelens" target="_blank" rel="noreferrer">LSP code lenses</a></strong> — #266 (⊶ 02ddfadb) by <a href="https://github.com/jan-xyz" target="_blank" rel="noreferrer">@jan-xyz</a></summary>
+
+↠ Before [LSP code lenses][nvim-docs-lsp#codelens] were highlighted with the default color which has been changed to make it less visually intrusive, like other UI related elements, e.g. messages of linters.
+
+<p align="center"><strong>Before</strong></p>
+<p align="center"><img src="https://user-images.githubusercontent.com/5249233/125171712-d1caef80-e1b5-11eb-8a40-95d7e2a79bbd.png" width="75%" /></p>
+
+<p align="center"><strong>After</strong></p>
+<p align="center"><img src="https://user-images.githubusercontent.com/5249233/125171722-da232a80-e1b5-11eb-9073-5fb3795d1136.png" width="75%" /></p>
+
+</details>
+
+## Improvements
+
+### Syntax
+
+<details>
+<summary><strong>Prevent aggressive error highlighting</strong> — #269 ⇄ #270 (⊶ e3e8a75c) by <a href="https://github.com/jan-xyz" target="_blank" rel="noreferrer">@jan-xyz</a></summary>
+
+↠ The `TSError` group is used to [highlight syntax/parser errors][nvim-treesitter/nvim-treesitter-blob-fb5d6e04#l493-l495] which caused an aggressive styling where the background color of many syntax elements was rendered with `nord11` during typing. This is a known problem and was fixed by many other themes by removing the group again. One of the [core maintainers of `nvim-treesitter` provided a solution by remapping groups][nvim-treesitter/nvim-treesitter#78#comment-647140700] and also mentioned that the group is [styled by the `nvim-treesitter` plugin but the active theme][nvim-treesitter/nvim-treesitter#1016#comment-797049591].
+
+Syntax errors can still be highlighted through linters and parsers like [Neovim's LSP][neovim/nvim-lspconfig] can still be used instead to highlight errors with the correct style, e.g. only change the foreground color of a single word.
+
+<p align="center"><img src="https://user-images.githubusercontent.com/22193688/126706481-bee2564c-8aa7-4d44-b666-794065809899.png" width="75%" /></p>
+
+</details>
+
 # 0.17.0
 
 ![Release Date: 2021-07-10](https://img.shields.io/static/v1.svg?style=flat-square&label=Release%20Date&message=2021-07-10&colorA=4c566a&colorB=88c0d0) [![Project Board](https://img.shields.io/static/v1.svg?style=flat-square&label=Project%20Board&message=0.17.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/projects/23) [![Milestone](https://img.shields.io/static/v1.svg?style=flat-square&label=Milestone&message=0.17.0&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0)](https://github.com/arcticicestudio/nord-vim/milestone/19)
@@ -48,7 +98,7 @@ Even though Neovim divides more and more from Vim through specific features like
 <details>
 <summary><strong>Support for the <a href="https://github.com/StanAngeloff/php.vim" target="_blank" rel="noreferrer">php.vim</a> plugin</strong> — #218, #262 ⇄ #263 (⊶ b3c46c87, 07452c71) by <a href="https://github.com/pirey" target="_blank" rel="noreferrer">@pirey</a></summary>
 
-↠ In [arcticicestudio/nord-vim#218][1] new highlighting groups for the bundled PHP syntax were added to improve the highlighting of classes, function and methods and the overall syntax token detection, but they are actually defined by the [php.vim][stanangeloff/php.vim] plugin. Therefore the added highlighting calls have been moved to a plugin section.
+↠ In [arcticicestudio/nord-vim#218][] new highlighting groups for the bundled PHP syntax were added to improve the highlighting of classes, function and methods and the overall syntax token detection, but they are actually defined by the [php.vim][stanangeloff/php.vim] plugin. Therefore the added highlighting calls have been moved to a plugin section.
 Additionally, the `phpClassExtends` and `phpClassImplements` groups have been added to improve the highlighting for classes that implement or extended interfaces/classes. The `phpUseClass` has also been added to improve the highlighting for imports.
 
 To improve the highlighting with the bundled PHP syntax, the [following options][vim-docs#php_syntax] can be set:
@@ -813,7 +863,7 @@ To optimally improve the highlighting `nord3` will now be used as background col
 
 ### Configurations
 
-❯ Added a configuration to enable [italic comments](https://github.com/arcticicestudio/nord-vim#italic-comments).  
+❯ Added a configuration to enable [italic comments](https://github.com/arcticicestudio/nord-vim#italic-comments).
 To adhere to the Nord style guide this option is disabled by default. It can be enabled by setting the `g:nord_italic_comments` variable to `1`.
 
 ```vim
@@ -839,7 +889,7 @@ let g:nord_italic_comments = 1
 
 ### Documentation
 
-❯ Added the new terminal emulator port project [Nord Hyper](https://github.com/arcticicestudio/nord-hyper)  
+❯ Added the new terminal emulator port project [Nord Hyper](https://github.com/arcticicestudio/nord-hyper)
 [![Nord Hyper](https://cdn.rawgit.com/arcticicestudio/nord/develop/src/assets/nord-hyper-banner.svg)](https://github.com/arcticicestudio/nord-hyper)
 
 # 0.3.0
@@ -850,7 +900,7 @@ let g:nord_italic_comments = 1
 
 ### Plugin Support
 
-❯ The [Nord lightline.vim][nord-lightline] UI plugin theme now includes better support for the [tmuxline.vim](https://github.com/edkolev/tmuxline.vim) plugin. Before this implementation text shown in the main segment of the tmuxline, generated via the `:Tmuxline lightline` command, has been colorized using `nord0` which resulted in unreadable text due to a `nord3` background.  
+❯ The [Nord lightline.vim][nord-lightline] UI plugin theme now includes better support for the [tmuxline.vim](https://github.com/edkolev/tmuxline.vim) plugin. Before this implementation text shown in the main segment of the tmuxline, generated via the `:Tmuxline lightline` command, has been colorized using `nord0` which resulted in unreadable text due to a `nord3` background.
 This has been fixed by using `nord5` as foreground color. (@scottwillmoore, #11, 4ea37f7e)
 
 <p align="center"><strong>Before</strong><br><img src="https://cloud.githubusercontent.com/assets/9512557/21741900/4f792f5e-d537-11e6-9e69-09ff11b60c4e.png"/><br><strong>After</strong><br><img src="https://cloud.githubusercontent.com/assets/7836623/21954034/15b87d1e-da47-11e6-9e70-a74aea14c378.png"/><br><strong>With unicode separators</strong><br><img src="https://cloud.githubusercontent.com/assets/7836623/21954058/7a7c5266-da47-11e6-8f1f-0203d5270c51.png"/><br><strong>Without specified configurations (tmuxline.vim autodetect)</strong><br><img src="https://cloud.githubusercontent.com/assets/7836623/21954072/931669e2-da47-11e6-8db3-cbdf9d6681f1.png"/></p>
@@ -954,14 +1004,17 @@ otherwise Markdown elements are not parsed and rendered!
 [itchyny/lightline-adv-config]: https://github.com/itchyny/lightline.vim#advanced-configuration
 [itchyny/lightline.vim-gh-257]: https://github.com/itchyny/lightline.vim/pull/257
 [lesscss-doc-fn-lighten]: http://lesscss.org/functions/#color-operations-lighten
+[liuchengxu/vim-clap]: https://github.com/liuchengxu/vim-clap
 [neoclide/coc.nvim]: https://github.com/neoclide/coc.nvim
+[neovim-docs-lsp]: https://neovim.io/doc/user/lsp.html
+[neovim/nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
 [nord-atom-syntax-pr-47]: https://github.com/arcticicestudio/nord-atom-syntax/pull/47
 [nord-config-port-vim#uni_st_line]: https://www.nordtheme.com/docs/ports/vim/configuration#uniform-status-lines
 [nord-docs-config-font-bold]: https://www.nordtheme.com/ports/vim/configuration#bold-styles
 [nord-gh]: https://github.com/arcticicestudio/nord
-[nord-home]: https://www.nordtheme.com/ports/vim
 [nord-lightline]: https://github.com/arcticicestudio/nord-vim/blob/develop/autoload/lightline/colorscheme/nord.vim
 [nord]: https://www.nordtheme.com
+[pandoc]: https://pandoc.org
 [plugin-ale]: https://github.com/w0rp/ale
 [plugin-ctrlp]: https://github.com/ctrlpvim/ctrlp.vim
 [plugin-junegunn/vim-plug]: https://github.com/junegunn/vim-plug
@@ -977,11 +1030,11 @@ otherwise Markdown elements are not parsed and rendered!
 [readme-config-underline-support]: https://github.com/arcticicestudio/nord-vim#underline-support
 [readme-config-uniform-diff-background]: https://github.com/arcticicestudio/nord-vim#uniform-diff-background
 [readme-config-uniform-statusline-background]: https://github.com/arcticicestudio/nord-vim#uniform-status-lines
-[readme-config]: https://github.com/arcticicestudio/nord-vim#configuration
 [rust]: https://www.rust-lang.org
 [vdoc-fchar]: http://vimdoc.sourceforge.net/htmldoc/options.html#'fillchars'
 [vdoc-vsplit]: http://vimdoc.sourceforge.net/htmldoc/syntax.html#hl-VertSplit
 [vim-doc-diffadd]: http://vimdoc.sourceforge.net/htmldoc/syntax.html#hl-DiffAdd
+[vim-pandoc/vim-pandoc-syntax]: https://github.com/vim-pandoc/vim-pandoc-syntax
 [yaml]: http://yaml.org
 
 <!-- v0.11.0 -->
@@ -1018,7 +1071,6 @@ otherwise Markdown elements are not parsed and rendered!
 [gh-user-nixtrace]: https://github.com/nixtrace
 [gh-user-vasilescur]: https://github.com/vasilescur
 [mhinz/vim-startify]: https://github.com/mhinz/vim-startify
-[nord-config-port-vim#uni_st_line]: https://www.nordtheme.com/docs/ports/vim/configuration#uniform-status-lines
 [vim/vim-diff#d9b0d83b...017ba07f]: https://github.com/vim/vim/compare/d9b0d83b13d2691e4544709abd87eac004715175...017ba07fa2cdc578245618717229444fd50c470d#diff-80fffb3e9c20e93e5b2328a9a20e19c
 [vim/vim-rel-v8.1.2029]: https://github.com/vim/vim/releases/tag/v8.1.2029
 [vim/vim#4933]: https://github.com/vim/vim/pull/4933
@@ -1035,7 +1087,6 @@ otherwise Markdown elements are not parsed and rendered!
 [gh-user-iamdidev]: https://github.com/iamdidev
 [gh-user-ikalnytskyi]: https://github.com/ikalnytskyi
 [herringtonharkholme/yats.vim]: https://github.com/HerringtonDarkholme/yats.vim
-[liuchengxu/vim-clap]: https://github.com/liuchengxu/vim-clap
 [ts-docs-decorators]: https://www.typescriptlang.org/docs/handbook/decorators.html
 [ts-docs-jsx]: https://www.typescriptlang.org/docs/handbook/jsx.html
 [typescript]: https://www.typescriptlang.org
@@ -1051,26 +1102,27 @@ otherwise Markdown elements are not parsed and rendered!
 [gh-user-crispgm]: https://github.com/crispgm
 [gh-user-ojroques]: https://github.com/ojroques
 [latex]: https://www.latex-project.org
-[liuchengxu/vim-clap]: https://github.com/liuchengxu/vim-clap
 [nathanaelkane/vim-indent-guides]: https://github.com/nathanaelkane/vim-indent-guides
 [nathanaelkane/vim-indent-guides#custom_color]: https://github.com/nathanaelkane/vim-indent-guides#setting-custom-indent-colors
-[neoclide/coc.nvim]: https://github.com/neoclide/coc.nvim
-[neovim-docs-lsp]: https://neovim.io/doc/user/lsp.html
 [neovim/neovim-ms#19]: https://github.com/neovim/neovim/milestone/19
 [neovim/neovim#12655]: https://github.com/neovim/neovim#12655
 [overleaf-latex-learn-math_expr]: https://www.overleaf.com/learn/latex/mathematical_expressions
-[pandoc]: https://pandoc.org
 [stanangeloff/php.vim]: https://github.com/StanAngeloff/php.vim
 [vim-docs#php_syntax]: https://vimhelp.org/syntax.txt.html#ft%2dphp%2dsyntax
-[vim-pandoc/vim-pandoc-syntax]: https://github.com/vim-pandoc/vim-pandoc-syntax
 [wikip-greek_alphabet]: https://en.wikipedia.org/wiki/Greek_alphabet
 
 <!-- 0.17.0 -->
 
 [gh-compare-tag-v0.16.0_v0.17.0]: https://github.com/arcticicestudio/nord-vim/compare/v0.16.0...v0.17.0
-[neovim-docs-lsp]: https://neovim.io/doc/user/lsp.html
 [neovim/neovim-v0.5.0]: https://github.com/neovim/neovim/releases/tag/v0.5.0
-[neovim/nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
 [nvim-treesitter/nvim-treesitter-blob-90f15d9]: https://github.com/nvim-treesitter/nvim-treesitter/blob/90f15d9/plugin/nvim-treesitter.vim
 [nvim-treesitter/nvim-treesitter]: https://github.com/nvim-treesitter/nvim-treesitter
 [tree-sitter/tree-sitter]: https://github.com/tree-sitter/tree-sitter
+
+<!-- 0.18.0 -->
+
+[gh-compare-tag-v0.17.0_v0.18.0]: https://github.com/arcticicestudio/nord-vim/compare/v0.17.0...v0.18.0
+[nvim-docs-lsp#codelens]: https://neovim.io/doc/user/lsp.html#lsp-highlight-codelens
+[nvim-treesitter/nvim-treesitter-blob-fb5d6e04#l493-l495]: https://github.com/nvim-treesitter/nvim-treesitter/blob/fb5d6e04/doc/nvim-treesitter.txt#L493-L495
+[nvim-treesitter/nvim-treesitter#1016#comment-797049591]: https://github.com/nvim-treesitter/nvim-treesitter/issues/1016#issuecomment-797049591
+[nvim-treesitter/nvim-treesitter#78#comment-647140700]: https://github.com/nvim-treesitter/nvim-treesitter/issues/78#issuecomment-647140700

--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -5,7 +5,7 @@
 " Repository: https://github.com/arcticicestudio/nord-vim
 " License: MIT
 
-let s:nord_vim_version="0.16.0"
+let s:nord_vim_version="0.17.0"
 let g:airline#themes#nord#palette = {}
 
 let s:nord0_gui = "#2E3440"

--- a/autoload/airline/themes/nord.vim
+++ b/autoload/airline/themes/nord.vim
@@ -5,7 +5,7 @@
 " Repository: https://github.com/arcticicestudio/nord-vim
 " License: MIT
 
-let s:nord_vim_version="0.17.0"
+let s:nord_vim_version="0.18.0"
 let g:airline#themes#nord#palette = {}
 
 let s:nord0_gui = "#2E3440"

--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -5,7 +5,7 @@
 " Repository: https://github.com/arcticicestudio/nord-vim
 " License: MIT
 
-let s:nord_vim_version="0.16.0"
+let s:nord_vim_version="0.17.0"
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
 let s:nord0 = ["#2E3440", "NONE"]

--- a/autoload/lightline/colorscheme/nord.vim
+++ b/autoload/lightline/colorscheme/nord.vim
@@ -5,7 +5,7 @@
 " Repository: https://github.com/arcticicestudio/nord-vim
 " License: MIT
 
-let s:nord_vim_version="0.17.0"
+let s:nord_vim_version="0.18.0"
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
 let s:nord0 = ["#2E3440", "NONE"]

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -277,6 +277,7 @@ call s:hi("Comment", s:nord3_gui_bright, "", s:nord3_term, "", s:italicize_comme
 call s:hi("Conceal", "", "NONE", "", "NONE", "", "")
 call s:hi("Conditional", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("Constant", s:nord4_gui, "", "NONE", "", "", "")
+call s:hi("Decorator", s:nord12_gui, "", s:nord12_term, "", "", "")
 call s:hi("Define", s:nord9_gui, "", s:nord9_term, "", "", "")
 call s:hi("Delimiter", s:nord6_gui, "", s:nord6_term, "", "", "")
 call s:hi("Exception", s:nord9_gui, "", s:nord9_term, "", "", "")
@@ -301,8 +302,10 @@ call s:hi("Tag", s:nord4_gui, "", "", "", "", "")
 call s:hi("Todo", s:nord13_gui, "NONE", s:nord13_term, "NONE", "", "")
 call s:hi("Type", s:nord9_gui, "", s:nord9_term, "", "NONE", "")
 call s:hi("Typedef", s:nord9_gui, "", s:nord9_term, "", "", "")
+hi! link Annotation Decorator
 hi! link Macro Define
 hi! link PreCondit PreProc
+hi! link Variable Identifier
 
 "+-----------+
 "+ Languages +
@@ -686,6 +689,25 @@ hi! link jsThis Keyword
 hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword
 hi! link jsRegexpString SpecialChar
+
+" tree-sitter
+" > nvim-treesitter/nvim-treesitter
+if has("nvim")
+  hi! link TSAnnotation Annotation
+  hi! link TSConstBuiltin Constant
+  hi! link TSConstructor Function
+  hi! link TSEmphasis Italic
+  hi! link TSError Error
+  hi! link TSFuncBuiltin Function
+  hi! link TSFuncMacro Function
+  hi! link TSStringRegex SpecialChar
+  hi! link TSStrong Bold
+  hi! link TSStructure Structure
+  hi! link TSTagDelimiter TSTag
+  hi! link TSUnderline Underline
+  hi! link TSVariable Variable
+  hi! link TSVariableBuiltin Keyword
+endif
 
 " TypeScript
 " > HerringtonDarkholme/yats.vim

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -13,7 +13,7 @@ if version > 580
 endif
 
 let g:colors_name = "nord"
-let s:nord_vim_version="0.16.0"
+let s:nord_vim_version="0.17.0"
 set background=dark
 
 let s:nord0_gui = "#2E3440"

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -366,6 +366,7 @@ hi! link awkVariables Identifier
 call s:hi("cIncluded", s:nord7_gui, "", s:nord7_term, "", "", "")
 hi! link cOperator Operator
 hi! link cPreCondit PreCondit
+hi! link cConstant Type
 
 call s:hi("cmakeGeneratorExpression", s:nord10_gui, "", s:nord10_term, "", "", "")
 

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -231,6 +231,9 @@ call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
 call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
 call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
 
+"+- Neovim LspSignatureHelp -+
+call s:hi("LspSignatureActiveParameter", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
+
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -226,6 +226,11 @@ call s:hi("DiagnosticUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "und
 call s:hi("DiagnosticUnderlineInfo" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
 call s:hi("DiagnosticUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
 
+"+- Neovim DocumentHighlight -+
+call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
+call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
+call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
+
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -726,7 +726,7 @@ endif
 "+--- Languages ---+
 " Haskell
 " > neovimhaskell/haskell-vim
-if exist('g:cabal_indent_section')
+if exists('g:cabal_indent_section')
   call s:hi("haskellPreProc", s:nord10_gui, "", s:nord10_term, "", "", "")
   call s:hi("haskellType", s:nord7_gui, "", s:nord7_term, "", "", "")
   hi! link haskellPragma haskellPreProc
@@ -859,7 +859,7 @@ hi! link mkdDelimiter Keyword
 
 " PHP
 " > StanAngeloff/php.vim
-if exist('g:php_version_id')
+if exists('g:php_version_id')
   call s:hi("phpClass", s:nord7_gui, "", s:nord7_term, "", "", "")
   call s:hi("phpClassImplements", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
   hi! link phpClassExtends phpClass

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -185,19 +185,14 @@ call s:hi("SpellLocal", s:nord5_gui, s:nord0_gui, s:nord5_term, "NONE", "undercu
 call s:hi("SpellRare", s:nord6_gui, s:nord0_gui, s:nord6_term, "NONE", "undercurl", s:nord6_gui)
 call s:hi("Visual", "", s:nord2_gui, "", s:nord1_term, "", "")
 call s:hi("VisualNOS", "", s:nord2_gui, "", s:nord1_term, "", "")
-"+- Neovim Support -+
-call s:hi("healthError", s:nord11_gui, s:nord1_gui, s:nord11_term, s:nord1_term, "", "")
-call s:hi("healthSuccess", s:nord14_gui, s:nord1_gui, s:nord14_term, s:nord1_term, "", "")
-call s:hi("healthWarning", s:nord13_gui, s:nord1_gui, s:nord13_term, s:nord1_term, "", "")
-call s:hi("TermCursorNC", "", s:nord1_gui, "", s:nord1_term, "", "")
 
 "+- Vim 8 Terminal Colors -+
 if has('terminal')
   let g:terminal_ansi_colors = [s:nord1_gui, s:nord11_gui, s:nord14_gui, s:nord13_gui, s:nord9_gui, s:nord15_gui, s:nord8_gui, s:nord5_gui, s:nord3_gui, s:nord11_gui, s:nord14_gui, s:nord13_gui, s:nord9_gui, s:nord15_gui, s:nord7_gui, s:nord6_gui]
 endif
 
-"+- Neovim Terminal Colors -+
 if has('nvim')
+  "+- Neovim Terminal Colors -+
   let g:terminal_color_0 = s:nord1_gui
   let g:terminal_color_1 = s:nord11_gui
   let g:terminal_color_2 = s:nord14_gui
@@ -214,25 +209,31 @@ if has('nvim')
   let g:terminal_color_13 = s:nord15_gui
   let g:terminal_color_14 = s:nord7_gui
   let g:terminal_color_15 = s:nord6_gui
+
+  "+- Neovim Support -+
+  call s:hi("healthError", s:nord11_gui, s:nord1_gui, s:nord11_term, s:nord1_term, "", "")
+  call s:hi("healthSuccess", s:nord14_gui, s:nord1_gui, s:nord14_term, s:nord1_term, "", "")
+  call s:hi("healthWarning", s:nord13_gui, s:nord1_gui, s:nord13_term, s:nord1_term, "", "")
+  call s:hi("TermCursorNC", "", s:nord1_gui, "", s:nord1_term, "", "")
+
+  "+- Neovim Diagnostics API -+
+  call s:hi("DiagnosticWarn", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("DiagnosticError" , s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("DiagnosticInfo" , s:nord8_gui, "", s:nord8_term, "", "", "")
+  call s:hi("DiagnosticHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
+  call s:hi("DiagnosticUnderlineWarn" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+  call s:hi("DiagnosticUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+  call s:hi("DiagnosticUnderlineInfo" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
+  call s:hi("DiagnosticUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+  
+  "+- Neovim DocumentHighlight -+
+  call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
+  call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
+  call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
+  
+  "+- Neovim LspSignatureHelp -+
+  call s:hi("LspSignatureActiveParameter", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
 endif
-
-"+- Neovim Diagnostics API -+
-call s:hi("DiagnosticWarn", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("DiagnosticError" , s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("DiagnosticInfo" , s:nord8_gui, "", s:nord8_term, "", "", "")
-call s:hi("DiagnosticHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
-call s:hi("DiagnosticUnderlineWarn" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
-call s:hi("DiagnosticUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
-call s:hi("DiagnosticUnderlineInfo" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
-call s:hi("DiagnosticUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
-
-"+- Neovim DocumentHighlight -+
-call s:hi("LspReferenceText", "", s:nord3_gui, "", s:nord3_term, "", "")
-call s:hi("LspReferenceRead", "", s:nord3_gui, "", s:nord3_term, "", "")
-call s:hi("LspReferenceWrite", "", s:nord3_gui, "", s:nord3_term, "", "")
-
-"+- Neovim LspSignatureHelp -+
-call s:hi("LspSignatureActiveParameter", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
 
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
@@ -577,53 +578,67 @@ hi! link yamlDocumentStart Keyword
 "+--- UI ---+
 " ALE
 " > w0rp/ale
-call s:hi("ALEWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("ALEWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
-call s:hi("ALEError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+if exists('g:loaded_ale')
+  call s:hi("ALEWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("ALEErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("ALEWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+  call s:hi("ALEError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+endif
 
 " Coc
-" > neoclide/coc
-call s:hi("CocWarningHighlight" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
-call s:hi("CocErrorHighlight" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
-call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")
-call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
+" > neoclide/coc.vim
+if exists('g:did_coc_loaded')
+  call s:hi("CocWarningHighlight" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+  call s:hi("CocErrorHighlight" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+  call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")
+  call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
+endif
 
-" Neovim LSP
-" > neovim/nvim-lspconfig
-call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", "", "")
-if has("nvim-0.5")
-  call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
-  call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
-  call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
-  call s:hi("LspDiagnosticsDefaultHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
-  call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
-  call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
-  call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
-  call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+if has('nvim')
+  " Neovim LSP
+  " > neovim/nvim-lspconfig
+  if exists('g:lspconfig')
+    call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", "", "")
+    if has("nvim-0.5")
+      call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
+      call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
+      call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
+      call s:hi("LspDiagnosticsDefaultHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
+      call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+      call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+      call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
+      call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+    endif
+  endif
 endif
 
 " GitGutter
 " > airblade/vim-gitgutter
-call s:hi("GitGutterAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
-call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+if exists('g:loaded_gitgutter')
+  call s:hi("GitGutterAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
+  call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+endif
 
 " Signify
 " > mhinz/vim-signify
-call s:hi("SignifySignAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
-call s:hi("SignifySignChange", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("SignifySignChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("SignifySignDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+if exists('g:loaded_signify')
+  call s:hi("SignifySignAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
+  call s:hi("SignifySignChange", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("SignifySignChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("SignifySignDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+endif
 
 " fugitive.vim
 " > tpope/vim-fugitive
-call s:hi("gitcommitDiscardedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("gitcommitUntrackedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("gitcommitSelectedFile", s:nord14_gui, "", s:nord14_term, "", "", "")
+if exists('g:loaded_fugitive')
+  call s:hi("gitcommitDiscardedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("gitcommitUntrackedFile", s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("gitcommitSelectedFile", s:nord14_gui, "", s:nord14_term, "", "", "")
+endif
 
 " davidhalter/jedi-vim
 call s:hi("jediFunction", s:nord4_gui, s:nord3_gui, "", s:nord3_term, "", "")
@@ -631,68 +646,82 @@ call s:hi("jediFat", s:nord8_gui, s:nord3_gui, s:nord8_term, s:nord3_term, s:und
 
 " NERDTree
 " > scrooloose/nerdtree
-call s:hi("NERDTreeExecFile", s:nord7_gui, "", s:nord7_term, "", "", "")
-hi! link NERDTreeDirSlash Keyword
-hi! link NERDTreeHelp Comment
+if exists('loaded_nerd_tree')
+  call s:hi("NERDTreeExecFile", s:nord7_gui, "", s:nord7_term, "", "", "")
+  hi! link NERDTreeDirSlash Keyword
+  hi! link NERDTreeHelp Comment
+endif
 
 " CtrlP
 " > ctrlpvim/ctrlp.vim
-hi! link CtrlPMatch Keyword
-hi! link CtrlPBufferHid Normal
+if exists('g:loaded_ctrlp')
+  hi! link CtrlPMatch Keyword
+  hi! link CtrlPBufferHid Normal
+endif
 
 " vim-clap
 " > liuchengxu/vim-clap
-call s:hi("ClapDir", s:nord4_gui, "", "", "", "", "")
-call s:hi("ClapDisplay", s:nord4_gui, s:nord1_gui, "", s:nord1_term, "", "")
-call s:hi("ClapFile", s:nord4_gui, "", "", "NONE", "", "")
-call s:hi("ClapMatches", s:nord8_gui, "", s:nord8_term, "", "", "")
-call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
-call s:hi("ClapSelectedSign", s:nord9_gui, "", s:nord9_term, "", "", "")
-
-let s:clap_matches = [
-        \ [s:nord8_gui,  s:nord8_term] ,
-        \ [s:nord9_gui,  s:nord9_term] ,
-        \ [s:nord10_gui, s:nord10_term] ,
-        \ ]
-for s:nord_clap_match_i in range(1,12)
-  let clap_match_color = s:clap_matches[s:nord_clap_match_i % len(s:clap_matches) - 1]
-  call s:hi("ClapMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
-  call s:hi("ClapFuzzyMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
-endfor
-unlet s:nord_clap_match_i
-
-hi! link ClapCurrentSelection PmenuSel
-hi! link ClapCurrentSelectionSign ClapSelectedSign
-hi! link ClapInput Pmenu
-hi! link ClapPreview Pmenu
-hi! link ClapProviderAbout ClapDisplay
-hi! link ClapProviderColon Type
-hi! link ClapProviderId Type
+if exists('g:loaded_clap')
+  call s:hi("ClapDir", s:nord4_gui, "", "", "", "", "")
+  call s:hi("ClapDisplay", s:nord4_gui, s:nord1_gui, "", s:nord1_term, "", "")
+  call s:hi("ClapFile", s:nord4_gui, "", "", "NONE", "", "")
+  call s:hi("ClapMatches", s:nord8_gui, "", s:nord8_term, "", "", "")
+  call s:hi("ClapNoMatchesFound", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("ClapSelected", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
+  call s:hi("ClapSelectedSign", s:nord9_gui, "", s:nord9_term, "", "", "")
+  
+  let s:clap_matches = [
+          \ [s:nord8_gui,  s:nord8_term] ,
+          \ [s:nord9_gui,  s:nord9_term] ,
+          \ [s:nord10_gui, s:nord10_term] ,
+          \ ]
+  for s:nord_clap_match_i in range(1,12)
+    let clap_match_color = s:clap_matches[s:nord_clap_match_i % len(s:clap_matches) - 1]
+    call s:hi("ClapMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
+    call s:hi("ClapFuzzyMatches" . s:nord_clap_match_i, clap_match_color[0], "", clap_match_color[1], "", "", "")
+  endfor
+  unlet s:nord_clap_match_i
+  
+  hi! link ClapCurrentSelection PmenuSel
+  hi! link ClapCurrentSelectionSign ClapSelectedSign
+  hi! link ClapInput Pmenu
+  hi! link ClapPreview Pmenu
+  hi! link ClapProviderAbout ClapDisplay
+  hi! link ClapProviderColon Type
+  hi! link ClapProviderId Type
+endif
 
 " vim-indent-guides
 " > nathanaelkane/vim-indent-guides
-call s:hi("IndentGuidesEven", "", s:nord1_gui, "", s:nord1_term, "", "")
-call s:hi("IndentGuidesOdd", "", s:nord2_gui, "", s:nord3_term, "", "")
+if exists('g:loaded_indent_guides')
+  call s:hi("IndentGuidesEven", "", s:nord1_gui, "", s:nord1_term, "", "")
+  call s:hi("IndentGuidesOdd", "", s:nord2_gui, "", s:nord3_term, "", "")
+endif
 
 " vim-plug
 " > junegunn/vim-plug
-call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
+if exists('g:loaded_plug')
+  call s:hi("plugDeleted", s:nord11_gui, "", "", s:nord11_term, "", "")
+endif
 
 " vim-signature
 " > kshenoy/vim-signature
-call s:hi("SignatureMarkText", s:nord8_gui, "", s:nord8_term, "", "", "")
+if exists('g:loaded_Signature')
+  call s:hi("SignatureMarkText", s:nord8_gui, "", s:nord8_term, "", "", "")
+endif
 
 " vim-startify
 " > mhinz/vim-startify
-call s:hi("StartifyFile", s:nord6_gui, "", s:nord6_term, "", "", "")
-call s:hi("StartifyFooter", s:nord7_gui, "", s:nord7_term, "", "", "")
-call s:hi("StartifyHeader", s:nord8_gui, "", s:nord8_term, "", "", "")
-call s:hi("StartifyNumber", s:nord7_gui, "", s:nord7_term, "", "", "")
-call s:hi("StartifyPath", s:nord8_gui, "", s:nord8_term, "", "", "")
-hi! link StartifyBracket Delimiter
-hi! link StartifySlash Normal
-hi! link StartifySpecial Comment
+if exists('g:loaded_startify')
+  call s:hi("StartifyFile", s:nord6_gui, "", s:nord6_term, "", "", "")
+  call s:hi("StartifyFooter", s:nord7_gui, "", s:nord7_term, "", "", "")
+  call s:hi("StartifyHeader", s:nord8_gui, "", s:nord8_term, "", "", "")
+  call s:hi("StartifyNumber", s:nord7_gui, "", s:nord7_term, "", "", "")
+  call s:hi("StartifyPath", s:nord8_gui, "", s:nord8_term, "", "", "")
+  hi! link StartifyBracket Delimiter
+  hi! link StartifySlash Normal
+  hi! link StartifySpecial Comment
+endif
 
 "+--- Languages ---+
 " Haskell
@@ -714,45 +743,49 @@ hi! link jsRegexpString SpecialChar
 
 " Pandoc
 " > vim-pandoc/vim-pandoc-syntax
-call s:hi("pandocDefinitionBlockTerm", s:nord7_gui, "", s:nord7_term, "", s:italic, "")
-call s:hi("pandocTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
-hi! link pandocAtxHeader markdownH1
-hi! link pandocBlockQuote markdownBlockquote
-hi! link pandocCiteAnchor Operator
-hi! link pandocCiteKey pandocReferenceLabel
-hi! link pandocDefinitionBlockMark Operator
-hi! link pandocEmphasis markdownItalic
-hi! link pandocFootnoteID pandocReferenceLabel
-hi! link pandocFootnoteIDHead markdownLinkDelimiter
-hi! link pandocFootnoteIDTail pandocFootnoteIDHead
-hi! link pandocGridTableDelims pandocTableDelims
-hi! link pandocGridTableHeader pandocTableDelims
-hi! link pandocOperator Operator
-hi! link pandocPipeTableDelims pandocTableDelims
-hi! link pandocReferenceDefinition pandocReferenceLabel
-hi! link pandocReferenceLabel markdownLinkText
-hi! link pandocReferenceURL markdownUrl
-hi! link pandocSimpleTableHeader pandocAtxHeader
-hi! link pandocStrong markdownBold
-hi! link pandocTableHeaderWord pandocAtxHeader
-hi! link pandocUListItemBullet Operator
-
-" tree-sitter
-" > nvim-treesitter/nvim-treesitter
-if has("nvim")
-  hi! link TSAnnotation Annotation
-  hi! link TSConstBuiltin Constant
-  hi! link TSConstructor Function
-  hi! link TSEmphasis Italic
-  hi! link TSFuncBuiltin Function
-  hi! link TSFuncMacro Function
-  hi! link TSStringRegex SpecialChar
-  hi! link TSStrong Bold
-  hi! link TSStructure Structure
-  hi! link TSTagDelimiter TSTag
-  hi! link TSUnderline Underline
-  hi! link TSVariable Variable
-  hi! link TSVariableBuiltin Keyword
+if exists('g:vim_pandoc_syntax_exists')
+  call s:hi("pandocDefinitionBlockTerm", s:nord7_gui, "", s:nord7_term, "", s:italic, "")
+  call s:hi("pandocTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
+  hi! link pandocAtxHeader markdownH1
+  hi! link pandocBlockQuote markdownBlockquote
+  hi! link pandocCiteAnchor Operator
+  hi! link pandocCiteKey pandocReferenceLabel
+  hi! link pandocDefinitionBlockMark Operator
+  hi! link pandocEmphasis markdownItalic
+  hi! link pandocFootnoteID pandocReferenceLabel
+  hi! link pandocFootnoteIDHead markdownLinkDelimiter
+  hi! link pandocFootnoteIDTail pandocFootnoteIDHead
+  hi! link pandocGridTableDelims pandocTableDelims
+  hi! link pandocGridTableHeader pandocTableDelims
+  hi! link pandocOperator Operator
+  hi! link pandocPipeTableDelims pandocTableDelims
+  hi! link pandocReferenceDefinition pandocReferenceLabel
+  hi! link pandocReferenceLabel markdownLinkText
+  hi! link pandocReferenceURL markdownUrl
+  hi! link pandocSimpleTableHeader pandocAtxHeader
+  hi! link pandocStrong markdownBold
+  hi! link pandocTableHeaderWord pandocAtxHeader
+  hi! link pandocUListItemBullet Operator
+endif
+  
+if has('nvim')
+  " tree-sitter
+  " > nvim-treesitter/nvim-treesitter
+  if exists('g:loaded_nvim_treesitter')
+    hi! link TSAnnotation Annotation
+    hi! link TSConstBuiltin Constant
+    hi! link TSConstructor Function
+    hi! link TSEmphasis Italic
+    hi! link TSFuncBuiltin Function
+    hi! link TSFuncMacro Function
+    hi! link TSStringRegex SpecialChar
+    hi! link TSStrong Bold
+    hi! link TSStructure Structure
+    hi! link TSTagDelimiter TSTag
+    hi! link TSUnderline Underline
+    hi! link TSVariable Variable
+    hi! link TSVariableBuiltin Keyword
+  endif
 endif
 
 " TypeScript
@@ -831,23 +864,25 @@ hi! link phpUseClass phpClass
 
 " Vimwiki
 " > vimwiki/vimwiki
-if !exists("g:vimwiki_hl_headers") || g:vimwiki_hl_headers == 0
-  for s:i in range(1,6)
-    call s:hi("VimwikiHeader".s:i, s:nord8_gui, "", s:nord8_term, "", s:bold, "")
-  endfor
-else
-  let s:vimwiki_hcolor_guifg = [s:nord7_gui, s:nord8_gui, s:nord9_gui, s:nord10_gui, s:nord14_gui, s:nord15_gui]
-  let s:vimwiki_hcolor_ctermfg = [s:nord7_term, s:nord8_term, s:nord9_term, s:nord10_term, s:nord14_term, s:nord15_term]
-  for s:i in range(1,6)
-    call s:hi("VimwikiHeader".s:i, s:vimwiki_hcolor_guifg[s:i-1] , "", s:vimwiki_hcolor_ctermfg[s:i-1], "", s:bold, "")
-  endfor
+if exists('g:loaded_vimwiki')
+  if !exists("g:vimwiki_hl_headers") || g:vimwiki_hl_headers == 0
+    for s:i in range(1,6)
+      call s:hi("VimwikiHeader".s:i, s:nord8_gui, "", s:nord8_term, "", s:bold, "")
+    endfor
+  else
+    let s:vimwiki_hcolor_guifg = [s:nord7_gui, s:nord8_gui, s:nord9_gui, s:nord10_gui, s:nord14_gui, s:nord15_gui]
+    let s:vimwiki_hcolor_ctermfg = [s:nord7_term, s:nord8_term, s:nord9_term, s:nord10_term, s:nord14_term, s:nord15_term]
+    for s:i in range(1,6)
+      call s:hi("VimwikiHeader".s:i, s:vimwiki_hcolor_guifg[s:i-1] , "", s:vimwiki_hcolor_ctermfg[s:i-1], "", s:bold, "")
+    endfor
+  endif
+  
+  call s:hi("VimwikiLink", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
+  hi! link VimwikiHeaderChar markdownHeadingDelimiter
+  hi! link VimwikiHR Keyword
+  hi! link VimwikiList markdownListMarker
 endif
-
-call s:hi("VimwikiLink", s:nord8_gui, "", s:nord8_term, "", s:underline, "")
-hi! link VimwikiHeaderChar markdownHeadingDelimiter
-hi! link VimwikiHR Keyword
-hi! link VimwikiList markdownListMarker
-
+  
 " YAML
 " > stephpy/vim-yaml
 call s:hi("yamlKey", s:nord7_gui, "", s:nord7_term, "", "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -72,68 +72,36 @@ let s:nord3_gui_brightened = [
   \ "#7b88a1",
 \ ]
 
-if !exists("g:nord_bold")
-  let g:nord_bold = 1
-endif
+let g:nord_bold = get(g:, "nord_bold", 1)
+let s:bold = (g:nord_bold == 0) ? "" : "bold,"
 
-let s:bold = "bold,"
-if g:nord_bold == 0
-  let s:bold = ""
-endif
+let g:nord_underline = get(g:, "nord_underline", 1)
+let s:underline = (g:nord_underline == 0) ? "NONE," : "underline,"
 
-if !exists("g:nord_italic")
-  if has("gui_running") || $TERM_ITALICS == "true"
-    let g:nord_italic = 1
-  else
-    let g:nord_italic = 0
-  endif
-endif
-
-let s:italic = "italic,"
-if g:nord_italic == 0
-  let s:italic = ""
-endif
-
-let s:underline = "underline,"
-if ! get(g:, "nord_underline", 1)
-  let s:underline = "NONE,"
-endif
+let g:nord_italic = get(g:, "nord_italic", (has("gui_running") || $TERM_ITALICS == "true"))
+let s:italic = (g:nord_italic == 0) ? "" : "italic,"
 
 let s:italicize_comments = ""
-if exists("g:nord_italic_comments")
-  if g:nord_italic_comments == 1
-    let s:italicize_comments = s:italic
-  endif
+if get(g:, "nord_italic_comments", 0)
+  let s:italicize_comments = s:italic
 endif
 
-if !exists('g:nord_uniform_status_lines')
-  let g:nord_uniform_status_lines = 0
-endif
-
-function! s:logWarning(msg)
-  echohl WarningMsg
-  echomsg 'nord: warning: ' . a:msg
-  echohl None
-endfunction
+let g:nord_uniform_status_lines = get(g:, "nord_uniform_status_lines", 0)
 
 if exists("g:nord_comment_brightness")
-  call s:logWarning('Variable g:nord_comment_brightness has been deprecated and will be removed in version 1.0.0!' .
+  echohl WarningMsg
+  echomsg 'nord: warning: Variable g:nord_comment_brightness has been deprecated and will be removed in version 1.0.0!' .
                    \' The comment color brightness has been increased by 10% by default.' .
-                   \' Please see https://github.com/arcticicestudio/nord-vim/issues/145 for more details.')
+                   \' Please see https://github.com/arcticicestudio/nord-vim/issues/145 for more details.'
+  echohl None
   let g:nord_comment_brightness = 10
 endif
 
-if !exists("g:nord_uniform_diff_background")
-  let g:nord_uniform_diff_background = 0
-endif
+let g:nord_uniform_diff_background = get(g:, "nord_uniform_diff_background", 0)
 
-if !exists("g:nord_cursor_line_number_background")
-  let g:nord_cursor_line_number_background = 0
-endif
+let g:nord_cursor_line_number_background = get(g:, "nord_cursor_line_number_background", 0)
 
-if !exists("g:nord_bold_vertical_split_line")
-  let g:nord_bold_vertical_split_line = 0
-endif
+let g:nord_bold_vertical_split_line = get(g:, "nord_bold_vertical_split_line", 0)
 
 function! s:hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
   if a:guifg != ""

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -726,9 +726,11 @@ endif
 "+--- Languages ---+
 " Haskell
 " > neovimhaskell/haskell-vim
-call s:hi("haskellPreProc", s:nord10_gui, "", s:nord10_term, "", "", "")
-call s:hi("haskellType", s:nord7_gui, "", s:nord7_term, "", "", "")
-hi! link haskellPragma haskellPreProc
+if exist('g:cabal_indent_section')
+  call s:hi("haskellPreProc", s:nord10_gui, "", s:nord10_term, "", "", "")
+  call s:hi("haskellType", s:nord7_gui, "", s:nord7_term, "", "", "")
+  hi! link haskellPragma haskellPreProc
+endif
 
 " JavaScript
 " > pangloss/vim-javascript
@@ -790,44 +792,46 @@ endif
 
 " TypeScript
 " > HerringtonDarkholme/yats.vim
-call s:hi("typescriptBOMWindowMethod", s:nord8_gui, "", s:nord8_term, "", s:italic, "")
-call s:hi("typescriptClassName", s:nord7_gui, "", s:nord7_term, "", "", "")
-call s:hi("typescriptDecorator", s:nord12_gui, "", s:nord12_term, "", "", "")
-call s:hi("typescriptInterfaceName", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
-call s:hi("typescriptRegexpString", s:nord13_gui, "", s:nord13_term, "", "", "")
-" TypeScript JSX
- call s:hi("tsxAttrib", s:nord7_gui, "", s:nord7_term, "", "", "")
-hi! link typescriptOperator Operator
-hi! link typescriptBinaryOp Operator
-hi! link typescriptAssign Operator
-hi! link typescriptMember Identifier
-hi! link typescriptDOMStorageMethod Identifier
-hi! link typescriptArrowFuncArg Identifier
-hi! link typescriptGlobal typescriptClassName
-hi! link typescriptBOMWindowProp Function
-hi! link typescriptArrowFuncDef Function
-hi! link typescriptAliasDeclaration Function
-hi! link typescriptPredefinedType Type
-hi! link typescriptTypeReference typescriptClassName
-hi! link typescriptTypeAnnotation Structure
-hi! link typescriptDocNamedParamType SpecialComment
-hi! link typescriptDocNotation Keyword
-hi! link typescriptDocTags Keyword
-hi! link typescriptImport Keyword
-hi! link typescriptExport Keyword
-hi! link typescriptTry Keyword
-hi! link typescriptVariable Keyword
-hi! link typescriptBraces Normal
-hi! link typescriptObjectLabel Normal
-hi! link typescriptCall Normal
-hi! link typescriptClassHeritage typescriptClassName
-hi! link typescriptFuncTypeArrow Structure
-hi! link typescriptMemberOptionality Structure
-hi! link typescriptNodeGlobal typescriptGlobal
-hi! link typescriptTypeBrackets Structure
-hi! link tsxEqual Operator
-hi! link tsxIntrinsicTagName htmlTag
-hi! link tsxTagName tsxIntrinsicTagName
+if exists('g:typescript_compiler_options')
+  call s:hi("typescriptBOMWindowMethod", s:nord8_gui, "", s:nord8_term, "", s:italic, "")
+  call s:hi("typescriptClassName", s:nord7_gui, "", s:nord7_term, "", "", "")
+  call s:hi("typescriptDecorator", s:nord12_gui, "", s:nord12_term, "", "", "")
+  call s:hi("typescriptInterfaceName", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
+  call s:hi("typescriptRegexpString", s:nord13_gui, "", s:nord13_term, "", "", "")
+  " TypeScript JSX
+   call s:hi("tsxAttrib", s:nord7_gui, "", s:nord7_term, "", "", "")
+  hi! link typescriptOperator Operator
+  hi! link typescriptBinaryOp Operator
+  hi! link typescriptAssign Operator
+  hi! link typescriptMember Identifier
+  hi! link typescriptDOMStorageMethod Identifier
+  hi! link typescriptArrowFuncArg Identifier
+  hi! link typescriptGlobal typescriptClassName
+  hi! link typescriptBOMWindowProp Function
+  hi! link typescriptArrowFuncDef Function
+  hi! link typescriptAliasDeclaration Function
+  hi! link typescriptPredefinedType Type
+  hi! link typescriptTypeReference typescriptClassName
+  hi! link typescriptTypeAnnotation Structure
+  hi! link typescriptDocNamedParamType SpecialComment
+  hi! link typescriptDocNotation Keyword
+  hi! link typescriptDocTags Keyword
+  hi! link typescriptImport Keyword
+  hi! link typescriptExport Keyword
+  hi! link typescriptTry Keyword
+  hi! link typescriptVariable Keyword
+  hi! link typescriptBraces Normal
+  hi! link typescriptObjectLabel Normal
+  hi! link typescriptCall Normal
+  hi! link typescriptClassHeritage typescriptClassName
+  hi! link typescriptFuncTypeArrow Structure
+  hi! link typescriptMemberOptionality Structure
+  hi! link typescriptNodeGlobal typescriptGlobal
+  hi! link typescriptTypeBrackets Structure
+  hi! link tsxEqual Operator
+  hi! link tsxIntrinsicTagName htmlTag
+  hi! link tsxTagName tsxIntrinsicTagName
+endif
 
 " Markdown
 " > plasticboy/vim-markdown
@@ -855,12 +859,14 @@ hi! link mkdDelimiter Keyword
 
 " PHP
 " > StanAngeloff/php.vim
-call s:hi("phpClass", s:nord7_gui, "", s:nord7_term, "", "", "")
-call s:hi("phpClassImplements", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
-hi! link phpClassExtends phpClass
-hi! link phpFunction Function
-hi! link phpMethod Function
-hi! link phpUseClass phpClass
+if exist('g:php_version_id')
+  call s:hi("phpClass", s:nord7_gui, "", s:nord7_term, "", "", "")
+  call s:hi("phpClassImplements", s:nord7_gui, "", s:nord7_term, "", s:bold, "")
+  hi! link phpClassExtends phpClass
+  hi! link phpFunction Function
+  hi! link phpMethod Function
+  hi! link phpUseClass phpClass
+endif
 
 " Vimwiki
 " > vimwiki/vimwiki

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -216,6 +216,16 @@ if has('nvim')
   let g:terminal_color_15 = s:nord6_gui
 endif
 
+"+- Neovim Diagnostics API -+
+call s:hi("DiagnosticWarn", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("DiagnosticError" , s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("DiagnosticInfo" , s:nord8_gui, "", s:nord8_term, "", "", "")
+call s:hi("DiagnosticHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
+call s:hi("DiagnosticUnderlineWarn" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+call s:hi("DiagnosticUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+call s:hi("DiagnosticUnderlineInfo" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
+call s:hi("DiagnosticUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+
 "+--- Gutter ---+
 call s:hi("CursorColumn", "", s:nord1_gui, "NONE", s:nord1_term, "", "")
 if g:nord_cursor_line_number_background == 0
@@ -575,14 +585,16 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 " Neovim LSP
 " > neovim/nvim-lspconfig
 call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", "", "")
-call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
-call s:hi("LspDiagnosticsDefaultHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
-call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
-call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
-call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
-call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+if has("nvim-0.5")
+  call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")
+  call s:hi("LspDiagnosticsDefaultHint" , s:nord10_gui, "", s:nord10_term, "", "", "")
+  call s:hi("LspDiagnosticsUnderlineWarning" , s:nord13_gui, "", s:nord13_term, "", "undercurl", "")
+  call s:hi("LspDiagnosticsUnderlineError" , s:nord11_gui, "", s:nord11_term, "", "undercurl", "")
+  call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
+  call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
+endif
 
 " GitGutter
 " > airblade/vim-gitgutter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -5,16 +5,16 @@
 " Repository: https://github.com/arcticicestudio/nord-vim
 " License: MIT
 
-if version > 580
+set background=dark
+if v:version > 580
   hi clear
-  if exists("syntax_on")
+  if exists("syntax_on") && (v:version < 800)
     syntax reset
   endif
 endif
 
 let g:colors_name = "nord"
 let s:nord_vim_version="0.18.0"
-set background=dark
 
 let s:nord0_gui = "#2E3440"
 let s:nord1_gui = "#3B4252"

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -723,7 +723,6 @@ if has("nvim")
   hi! link TSConstBuiltin Constant
   hi! link TSConstructor Function
   hi! link TSEmphasis Italic
-  hi! link TSError Error
   hi! link TSFuncBuiltin Function
   hi! link TSFuncMacro Function
   hi! link TSStringRegex SpecialChar

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -690,6 +690,31 @@ hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword
 hi! link jsRegexpString SpecialChar
 
+" Pandoc
+" > vim-pandoc/vim-pandoc-syntax
+call s:hi("pandocDefinitionBlockTerm", s:nord7_gui, "", s:nord7_term, "", s:italic, "")
+call s:hi("pandocTableDelims", s:nord3_gui, "", s:nord3_term, "", "", "")
+hi! link pandocAtxHeader markdownH1
+hi! link pandocBlockQuote markdownBlockquote
+hi! link pandocCiteAnchor Operator
+hi! link pandocCiteKey pandocReferenceLabel
+hi! link pandocDefinitionBlockMark Operator
+hi! link pandocEmphasis markdownItalic
+hi! link pandocFootnoteID pandocReferenceLabel
+hi! link pandocFootnoteIDHead markdownLinkDelimiter
+hi! link pandocFootnoteIDTail pandocFootnoteIDHead
+hi! link pandocGridTableDelims pandocTableDelims
+hi! link pandocGridTableHeader pandocTableDelims
+hi! link pandocOperator Operator
+hi! link pandocPipeTableDelims pandocTableDelims
+hi! link pandocReferenceDefinition pandocReferenceLabel
+hi! link pandocReferenceLabel markdownLinkText
+hi! link pandocReferenceURL markdownUrl
+hi! link pandocSimpleTableHeader pandocAtxHeader
+hi! link pandocStrong markdownBold
+hi! link pandocTableHeaderWord pandocAtxHeader
+hi! link pandocUListItemBullet Operator
+
 " tree-sitter
 " > nvim-treesitter/nvim-treesitter
 if has("nvim")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -574,6 +574,7 @@ call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
 
 " Neovim LSP
 " > neovim/nvim-lspconfig
+call s:hi("LspCodeLens", s:nord3_gui_bright, "", s:nord3_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultWarning", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultError" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("LspDiagnosticsDefaultInformation" , s:nord8_gui, "", s:nord8_term, "", "", "")

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -13,7 +13,7 @@ if version > 580
 endif
 
 let g:colors_name = "nord"
-let s:nord_vim_version="0.17.0"
+let s:nord_vim_version="0.18.0"
 set background=dark
 
 let s:nord0_gui = "#2E3440"


### PR DESCRIPTION
According to https://vimhelp.org/syntax.txt.html
and https://github.com/vim/colorschemes/issues/34
there is no need to call `syntax reset` after
`hi clear`. Not doing so prevents sourcing syncolor.vim
twice.