### PR TITLE
Add Gitsigns and Sneak support

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -582,12 +582,20 @@ call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 
+" Gitsigns
+" > lewis6991/gitsigns.nvim
+hi! link GitSignsCurrentLineBlame Comment
+
 " Signify
 " > mhinz/vim-signify
 call s:hi("SignifySignAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
 call s:hi("SignifySignChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("SignifySignChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("SignifySignDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
+
+" Sneak
+" > justinmk/vim-sneak
+hi! link Sneak Search
 
 " fugitive.vim
 " > tpope/vim-fugitive

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -573,6 +573,10 @@ if has('nvim')
     call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
     call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
   endif
+  
+  " Gitsigns
+  " > lewis6991/gitsigns.nvim
+  hi! link GitSignsCurrentLineBlame Comment
 endif
 
 " GitGutter
@@ -581,12 +585,6 @@ call s:hi("GitGutterAdd", s:nord14_gui, "", s:nord14_term, "", "", "")
 call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
-
-if has('nvim')
-  " Gitsigns
-  " > lewis6991/gitsigns.nvim
-  hi! link GitSignsCurrentLineBlame Comment
-endif
 
 " Signify
 " > mhinz/vim-signify

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -582,9 +582,11 @@ call s:hi("GitGutterChange", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("GitGutterChangeDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("GitGutterDelete", s:nord11_gui, "", s:nord11_term, "", "", "")
 
-" Gitsigns
-" > lewis6991/gitsigns.nvim
-hi! link GitSignsCurrentLineBlame Comment
+if has('nvim')
+  " Gitsigns
+  " > lewis6991/gitsigns.nvim
+  hi! link GitSignsCurrentLineBlame Comment
+endif
 
 " Signify
 " > mhinz/vim-signify


### PR DESCRIPTION
This adds support for [Gitsigns](https://github.com/lewis6991/gitsigns.nvim) and [Sneak](https://github.com/justinmk/vim-sneak).

#### Gitsigns (for current line blame)
Matches `Comment`

<img width="595" alt="CleanShot 2022-05-27 at 09 47 54@2x" src="https://user-images.githubusercontent.com/6104/170713199-eca91256-0c42-49bc-8679-a3eb7ccb4ac3.png">

#### Sneak
Matches `Search`

<img width="622" alt="CleanShot 2022-05-27 at 09 54 38@2x" src="https://user-images.githubusercontent.com/6104/170713524-d9ba80b0-ec35-4a60-b47e-bb9e23407a50.png">


