### PR TITLE
Add support for rainbow colors

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -573,7 +573,7 @@ if has('nvim')
     call s:hi("LspDiagnosticsUnderlineInformation" , s:nord8_gui, "", s:nord8_term, "", "undercurl", "")
     call s:hi("LspDiagnosticsUnderlineHint" , s:nord10_gui, "", s:nord10_term, "", "undercurl", "")
   endif
-  
+
   " Gitsigns
   " > lewis6991/gitsigns.nvim
   hi! link GitSignsCurrentLineBlame Comment
@@ -670,15 +670,17 @@ hi! link StartifyBracket Delimiter
 hi! link StartifySlash Normal
 hi! link StartifySpecial Comment
 
-" nvim-ts-rainbow
-" > p00f/nvim-ts-rainbow
-call s:hi("rainbowcol1", s:nord11_gui, "", s:nord11_term, "", "", "")
-call s:hi("rainbowcol2", s:nord12_gui, "", s:nord12_term, "", "", "")
-call s:hi("rainbowcol3", s:nord13_gui, "", s:nord13_term, "", "", "")
-call s:hi("rainbowcol4", s:nord14_gui, "", s:nord14_term, "", "", "")
-call s:hi("rainbowcol5", s:nord9_gui, "", s:nord9_term, "", "", "")
-call s:hi("rainbowcol6", s:nord10_gui, "", s:nord10_term, "", "", "")
-call s:hi("rainbowcol7", s:nord15_gui, "", s:nord15_term, "", "", "")
+if has('nvim)
+  " nvim-ts-rainbow
+  " > p00f/nvim-ts-rainbow
+  call s:hi("rainbowcol1", s:nord11_gui, "", s:nord11_term, "", "", "")
+  call s:hi("rainbowcol2", s:nord12_gui, "", s:nord12_term, "", "", "")
+  call s:hi("rainbowcol3", s:nord13_gui, "", s:nord13_term, "", "", "")
+  call s:hi("rainbowcol4", s:nord14_gui, "", s:nord14_term, "", "", "")
+  call s:hi("rainbowcol5", s:nord9_gui, "", s:nord9_term, "", "", "")
+  call s:hi("rainbowcol6", s:nord10_gui, "", s:nord10_term, "", "", "")
+  call s:hi("rainbowcol7", s:nord15_gui, "", s:nord15_term, "", "", "")
+endif
 
 "+--- Languages ---+
 " Haskell
@@ -722,7 +724,7 @@ hi! link pandocSimpleTableHeader pandocAtxHeader
 hi! link pandocStrong markdownBold
 hi! link pandocTableHeaderWord pandocAtxHeader
 hi! link pandocUListItemBullet Operator
-  
+
 if has('nvim')
   " tree-sitter
   " > nvim-treesitter/nvim-treesitter

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -670,6 +670,16 @@ hi! link StartifyBracket Delimiter
 hi! link StartifySlash Normal
 hi! link StartifySpecial Comment
 
+" nvim-ts-rainbow
+" > p00f/nvim-ts-rainbow
+call s:hi("rainbowcol1", s:nord11_gui, "", s:nord11_term, "", "", "")
+call s:hi("rainbowcol2", s:nord12_gui, "", s:nord12_term, "", "", "")
+call s:hi("rainbowcol3", s:nord13_gui, "", s:nord13_term, "", "", "")
+call s:hi("rainbowcol4", s:nord14_gui, "", s:nord14_term, "", "", "")
+call s:hi("rainbowcol5", s:nord9_gui, "", s:nord9_term, "", "", "")
+call s:hi("rainbowcol6", s:nord10_gui, "", s:nord10_term, "", "", "")
+call s:hi("rainbowcol7", s:nord15_gui, "", s:nord15_term, "", "", "")
+
 "+--- Languages ---+
 " Haskell
 " > neovimhaskell/haskell-vim


### PR DESCRIPTION
There are plugins that make parentheses rainbow colored (meaning each pair is a different color). The one I use is [nvim-ts-rainbow](p00f/nvim-ts-rainbow). I think nord-vim should set the default rainbow colors for plugins like nvim-ts-rainbow to use so that users don't have to set it on their own. The colors I chose are red, orange, green, blue, darker blue, purple from the Nord theme. If the colors are not perfect, feel free to change them.