### PR TITLE
`pangloss/vim-javascript`: add missing links

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -681,8 +681,11 @@ hi! link haskellPragma haskellPreProc
 " > pangloss/vim-javascript
 call s:hi("jsGlobalNodeObjects", s:nord8_gui, "", s:nord8_term, "", s:italic, "")
 hi! link jsBrackets Delimiter
+hi! link jsBuiltinValues Keyword
 hi! link jsFuncCall Function
 hi! link jsFuncParens Delimiter
+hi! link jsModuleBraces Delimiter
+hi! link jsObjectBraces Delimiter
 hi! link jsThis Keyword
 hi! link jsNoise Delimiter
 hi! link jsPrototype Keyword


### PR DESCRIPTION
Add links to missing highlighting groups for pangloss/vim-javascript plugin