### PR TITLE
EditorConfig: Remove max_line_length for all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,6 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
-max_line_length = 160
 trim_trailing_whitespace = true
 
 # +-----------+


### PR DESCRIPTION
Having `max_line_length` for all files overrides useful line lengths defined (n)vim's ftplugins (e.g., gitcommit.vim sets `textwidth=72` for well-formed commit messages.