### PR TITLE
Explicitly higlighting CocErrorFloat.

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -562,6 +562,7 @@ call s:hi("CocWarningSign", s:nord13_gui, "", s:nord13_term, "", "", "")
 call s:hi("CocErrorSign" , s:nord11_gui, "", s:nord11_term, "", "", "")
 call s:hi("CocInfoSign" , s:nord8_gui, "", s:nord8_term, "", "", "")
 call s:hi("CocHintSign" , s:nord10_gui, "", s:nord10_term, "", "", "")
+call s:hi("CocErrorFloat" , s:nord15_gui, "", s:nord15_term, "", "", "")
 
 if has('nvim')
   " Neovim LSP


### PR DESCRIPTION

![image](https://github.com/nordtheme/vim/assets/2420811/b18b349f-49f8-4354-a02e-58dc698dc611)
VS
![image](https://github.com/nordtheme/vim/assets/2420811/76057a67-0426-4b3a-8c04-90d7dc994c0a)
