### PR TITLE
fix: visual selection not wisible when termguicolors disabled

### DIFF
--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -146,8 +146,8 @@ call s:hi("SpellBad", s:nord11_gui, s:nord0_gui, s:nord11_term, "NONE", "undercu
 call s:hi("SpellCap", s:nord13_gui, s:nord0_gui, s:nord13_term, "NONE", "undercurl", s:nord13_gui)
 call s:hi("SpellLocal", s:nord5_gui, s:nord0_gui, s:nord5_term, "NONE", "undercurl", s:nord5_gui)
 call s:hi("SpellRare", s:nord6_gui, s:nord0_gui, s:nord6_term, "NONE", "undercurl", s:nord6_gui)
-call s:hi("Visual", "", s:nord2_gui, "", s:nord1_term, "", "")
-call s:hi("VisualNOS", "", s:nord2_gui, "", s:nord1_term, "", "")
+call s:hi("Visual", "", s:nord2_gui, "NONE", s:nord1_term, "", "")
+call s:hi("VisualNOS", "", s:nord2_gui, "NONE", s:nord1_term, "", "")
 
 "+- Vim 8 Terminal Colors -+
 if has('terminal')


### PR DESCRIPTION
When the `termguicolor` option is not set within vim then a visual selection is not visible because the selection color is the same as the background color of the line. The following picture shows how it looks:

![grafik](https://github.com/nordtheme/vim/assets/14248802/196f669d-6553-4edc-ac4f-2070ca983608)

The changes in this pull request make the selection visible again:

![grafik](https://github.com/nordtheme/vim/assets/14248802/909f1bcc-88eb-47d7-b512-1979ad4d0120)
